### PR TITLE
Improve robustness and correctness of waiting for agent pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,10 @@ require (
 	// For runable plugin name fix: https://github.com/spf13/cobra/pull/2070
 	github.com/spf13/cobra v1.8.1-0.20231218005857-41227856cd73
 	go.uber.org/zap v1.27.0
+	k8s.io/api v0.28.4
+	k8s.io/apimachinery v0.28.4
+	k8s.io/cli-runtime v0.28.4
 	k8s.io/client-go v0.28.4
-)
-
-require (
-	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 )
 
 require (
@@ -24,17 +22,20 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
@@ -46,9 +47,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.28.4
-	k8s.io/apimachinery v0.28.4
-	k8s.io/cli-runtime v0.28.4
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
@@ -63,6 +65,8 @@ github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/pkg/gather/agent.go
+++ b/pkg/gather/agent.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
@@ -106,7 +107,8 @@ func (a *AgentPod) WaitUntilRunning() error {
 				return fmt.Errorf("agent pod %q terminated", a)
 			}
 		case watch.Error:
-			a.Log.Warnf("Agent pod %q watch error: %s", a, event)
+			err := apierrors.FromObject(event.Object)
+			return fmt.Errorf("agent pod %q watch error: %s", a, err)
 		case watch.Deleted:
 			return fmt.Errorf("agent pod %q was deleted", a)
 		}

--- a/pkg/gather/agent.go
+++ b/pkg/gather/agent.go
@@ -96,8 +96,8 @@ func (a *AgentPod) WaitUntilRunning() error {
 	for event := range watcher.ResultChan() {
 		switch event.Type {
 		case watch.Modified, watch.Added:
-			obj := event.Object.(*corev1.Pod)
-			switch obj.Status.Phase {
+			pod := event.Object.(*corev1.Pod)
+			switch pod.Status.Phase {
 			case corev1.PodRunning:
 				return nil
 			case corev1.PodFailed:

--- a/pkg/gather/agent.go
+++ b/pkg/gather/agent.go
@@ -91,6 +91,8 @@ func (a *AgentPod) WaitUntilRunning() error {
 		return err
 	}
 
+	defer watcher.Stop()
+
 	for event := range watcher.ResultChan() {
 		switch event.Type {
 		case watch.Modified:

--- a/pkg/gather/agent.go
+++ b/pkg/gather/agent.go
@@ -95,7 +95,7 @@ func (a *AgentPod) WaitUntilRunning() error {
 
 	for event := range watcher.ResultChan() {
 		switch event.Type {
-		case watch.Modified:
+		case watch.Modified, watch.Added:
 			obj := event.Object.(*corev1.Pod)
 			switch obj.Status.Phase {
 			case corev1.PodRunning:


### PR DESCRIPTION
- Restart watching after recoverable errors
- Stop watcher when done, fix resource leak
- Handle the unlikely case when the pod is running when receiving an Added event
- Return error (hopefully) helpful error when watching fail instead of logging a warning and timeout out
- Improve names
- Tidy go.mod - gather direct and indirect packages