### PR TITLE
Improve gather directory help and format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,8 +55,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&directory, "directory", "d", defaultGatherDirectory(),
-		"directory for storing gathered data")
+	rootCmd.Flags().StringVarP(&directory, "directory", "d", "",
+		"directory for storing gathered data (default \"gather.{timestamp}\")")
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", defaultKubeconfig(),
 		"the kubeconfig file to use")
 	rootCmd.Flags().StringSliceVar(&contexts, "contexts", nil,
@@ -74,6 +74,11 @@ type result struct {
 
 func gatherAll(cmd *cobra.Command, args []string) {
 	start := time.Now()
+
+	if directory == "" {
+		directory = defaultGatherDirectory()
+	}
+
 	log := createLogger()
 	defer log.Sync()
 
@@ -100,6 +105,10 @@ func gatherAll(cmd *cobra.Command, args []string) {
 		log.Infof("Gathering from namespace %q", namespace)
 	} else {
 		log.Infof("Gathering from all namespaces")
+	}
+
+	if !cmd.Flags().Changed("directory") {
+		log.Infof("Storing data in %q", directory)
 	}
 
 	wg := sync.WaitGroup{}
@@ -219,5 +228,5 @@ func loadConfig(kubeconfig string) (*api.Config, error) {
 }
 
 func defaultGatherDirectory() string {
-	return time.Now().Format("gather-20060102150405")
+	return time.Now().Format("gather.20060102150405")
 }


### PR DESCRIPTION
Previously the default directory showed the special template value:

    -d, --directory string    directory for storing gathered data (default "gather-20060102150405")

Which is never the actual value. Now we use zero value as default, and specify a default in the actual flag help:

    -d, --directory string    directory for storing gathered data (default "gather.{timestamp}")

The gather directory is generated after the command is run if the value is empty. To help users find the right directory, log the generated directory name:

    $ kubectl gather -n foo
    2024-05-24T20:14:14.442+0300	INFO	gather	Storing data in "gather.20240524201414"

The default name use now gather.timestamp instead of gather-timestamp to make the name different from user selected name, which are likely to use xxx-yyy-zzz format (like most names in k8s).