### PR TITLE
Group resources by group

### DIFF
--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -56,12 +56,14 @@ type resourceInfo struct {
 }
 
 // Name returns the full name of the reosurce, used as the directory name in the
-// gather directory.
+// gather directory. Resources with an empty group are gathered in the cluster
+// or namespace direcotry. Reosurces with non-empty group are gathered in a
+// group directory.
 func (r *resourceInfo) Name() string {
 	if r.GroupVersion.Group == "" {
 		return r.APIResource.Name
 	}
-	return r.APIResource.Name + "." + r.GroupVersion.Group
+	return r.GroupVersion.Group + "/" + r.APIResource.Name
 }
 
 func New(config *api.Config, directory string, opts Options) (*Gatherer, error) {


### PR DESCRIPTION
Previously we flattened the output to "resource.group" or "resource" (when group is empty). Now we gather resources with a non-empty group under the "group" directory.

This makes the output more compatible with `oc adm must-gather`, but it not the same, since must-gather output is inconsistent. In some cases it creates a fake "core" directory for resources with empty group.

Example output:

    $ tree -L 4 gather-all/dr1/namespaces/open-cluster-management-agent
    gather-all/dr1/namespaces/open-cluster-management-agent
    ├── apps
    │   ├── deployments
    │   │   ├── klusterlet-registration-agent.yaml
    │   │   └── klusterlet-work-agent.yaml
    │   └── replicasets
    │       ├── klusterlet-registration-agent-589d97cd97.yaml
    │       ├── klusterlet-work-agent-54df7bf9d9.yaml
    │       └── klusterlet-work-agent-8659b64b69.yaml
    ├── configmaps
    │   └── kube-root-ca.crt.yaml
    ├── events.k8s.io
    │   └── events
    │       ├── klusterlet-registration-agent-589d97cd97-lwcxm.17d27e3315d9bd26.yaml
    │       ├── klusterlet-work-agent.17d27e364b00c318.yaml
    │       ├── klusterlet-work-agent.17d27e37fca8f735.yaml
    │       ├── klusterlet-work-agent.17d27e3801934a53.yaml
    │       ├── klusterlet-work-agent.17d27e38045146ca.yaml
    │       └── klusterlet-work-agent-8659b64b69-7pxt9.17d27e3503e6b7f3.yaml
    ├── pods
    │   ├── klusterlet-registration-agent-589d97cd97-lwcxm
    │   │   └── registration-controller
    │   │       └── current.log
    │   ├── klusterlet-registration-agent-589d97cd97-lwcxm.yaml
    │   ├── klusterlet-work-agent-8659b64b69-7pxt9
    │   │   └── klusterlet-manifestwork-agent
    │   │       └── current.log
    │   └── klusterlet-work-agent-8659b64b69-7pxt9.yaml
    ├── rbac.authorization.k8s.io
    │   ├── rolebindings
    │   │   ├── open-cluster-management:management:klusterlet-registration:agent.yaml
    │   │   └── open-cluster-management:management:klusterlet-work:agent.yaml
    │   └── roles
    │       ├── open-cluster-management:management:klusterlet-registration:agent.yaml
    │       └── open-cluster-management:management:klusterlet-work:agent.yaml
    ├── secrets
    │   ├── bootstrap-hub-kubeconfig.yaml
    │   └── hub-kubeconfig-secret.yaml
    └── serviceaccounts
        ├── default.yaml
        ├── klusterlet-registration-sa.yaml
        └── klusterlet-work-sa.yaml

Part-of #3