### PR TITLE
Support enabling only specific addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 REGITRY ?= quay.io
 REPO ?= nirsof
 IMAGE ?= gather
-TAG ?= latest
+TAG ?= 0.2
 
 image := $(REGITRY)/$(REPO)/$(IMAGE):$(TAG)
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,64 @@ $ du -sh gather.remote.app/
 2.7M	gather.remote.app/
 ```
 
+## Enabling specific addons
+
+By default we gather additional data like pod container logs and rook
+commands and external logs stored on the nodes. To control gathering of
+additional data, you can use the `--addons` flag. If the flag is not set
+all addons are enabled.
+
+Gathering only resources:
+
+```
+$ kubectl gather --contexts dr1,dr2 --addons= -d gather.resources
+2024-06-01T02:13:08.117+0300	INFO	gather	Using kubeconfig "/home/nsoffer/.kube/config"
+2024-06-01T02:13:08.118+0300	INFO	gather	Gathering from all namespaces
+2024-06-01T02:13:08.119+0300	INFO	gather	Using addons []
+2024-06-01T02:13:08.119+0300	INFO	gather	Gathering from cluster "dr1"
+2024-06-01T02:13:08.119+0300	INFO	gather	Gathering from cluster "dr2"
+2024-06-01T02:13:08.942+0300	INFO	gather	Gathered 557 resources from cluster "dr1" in 0.823 seconds
+2024-06-01T02:13:08.946+0300	INFO	gather	Gathered 557 resources from cluster "dr2" in 0.828 seconds
+2024-06-01T02:13:08.946+0300	INFO	gather	Gathered 1114 resources from 2 clusters in 0.828 seconds
+```
+
+Gathering resource and pod container logs:
+
+```
+$ kubectl gather --contexts dr1,dr2 --addons logs -d gather.logs
+2024-06-01T02:12:07.775+0300	INFO	gather	Using kubeconfig "/home/nsoffer/.kube/config"
+2024-06-01T02:12:07.776+0300	INFO	gather	Gathering from all namespaces
+2024-06-01T02:12:07.777+0300	INFO	gather	Using addons ["logs"]
+2024-06-01T02:12:07.777+0300	INFO	gather	Gathering from cluster "dr1"
+2024-06-01T02:12:07.777+0300	INFO	gather	Gathering from cluster "dr2"
+2024-06-01T02:12:11.580+0300	INFO	gather	Gathered 553 resources from cluster "dr2" in 3.803 seconds
+2024-06-01T02:12:11.799+0300	INFO	gather	Gathered 553 resources from cluster "dr1" in 4.022 seconds
+2024-06-01T02:12:11.799+0300	INFO	gather	Gathered 1106 resources from 2 clusters in 4.022 seconds
+```
+
+Gathering everything:
+
+```
+$ kubectl gather --contexts dr1,dr2 -d gather.all
+2024-06-01T02:11:46.490+0300	INFO	gather	Using kubeconfig "/home/nsoffer/.kube/config"
+2024-06-01T02:11:46.492+0300	INFO	gather	Gathering from all namespaces
+2024-06-01T02:11:46.492+0300	INFO	gather	Using all addons
+2024-06-01T02:11:46.492+0300	INFO	gather	Gathering from cluster "dr1"
+2024-06-01T02:11:46.492+0300	INFO	gather	Gathering from cluster "dr2"
+2024-06-01T02:11:50.680+0300	INFO	gather	Gathered 549 resources from cluster "dr1" in 4.189 seconds
+2024-06-01T02:11:50.788+0300	INFO	gather	Gathered 549 resources from cluster "dr2" in 4.296 seconds
+2024-06-01T02:11:50.788+0300	INFO	gather	Gathered 1098 resources from 2 clusters in 4.297 seconds
+```
+
+Comparing the gathered data:
+
+```
+$ du -sh gather.*
+108M	gather.all
+35M	    gather.logs
+8.8M	gather.resources
+```
+
 ## Similar projects
 
 - [must-gather](https://github.com/openshift/must-gather) - similar tool

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -38,6 +38,7 @@ func localGather(clusters []*clusterConfig) {
 			Kubeconfig: kubeconfig,
 			Context:    cluster.Context,
 			Namespaces: namespaces,
+			Addons:     addons,
 			Log:        log.Named(cluster.Context),
 		}
 

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-const remoteDefaultImage = "quay.io/nirsof/gather:latest"
+const remoteDefaultImage = "quay.io/nirsof/gather:0.2"
 
 func remoteGather(clusters []*clusterConfig) {
 	start := time.Now()

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -101,6 +101,10 @@ func mustGatherCommand(context string, directory string) *exec.Cmd {
 		remoteArgs = append(remoteArgs, "--namespaces="+strings.Join(namespaces, ","))
 	}
 
+	if addons != nil {
+		remoteArgs = append(remoteArgs, "--addons="+strings.Join(addons, ","))
+	}
+
 	if len(remoteArgs) > 0 {
 		args = append(args, "--", "/usr/bin/gather")
 		args = append(args, remoteArgs...)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func runGather(cmd *cobra.Command, args []string) {
 	}
 
 	if len(namespaces) != 0 {
-		log.Infof("Gathering from namespaces %v", namespaces)
+		log.Infof("Gathering from namespaces %q", namespaces)
 	} else {
 		log.Infof("Gathering from all namespaces")
 	}

--- a/pkg/gather/addons.go
+++ b/pkg/gather/addons.go
@@ -5,25 +5,33 @@ package gather
 
 import (
 	"net/http"
+	"slices"
 
 	"k8s.io/client-go/rest"
 )
 
 func createAddons(config *rest.Config, client *http.Client, out *OutputDirectory, opts *Options, q Queuer) (map[string]Addon, error) {
-	logsAddon, err := NewLogsAddon(config, client, out, opts, q)
-	if err != nil {
-		return nil, err
+	registry := map[string]Addon{}
+
+	if addonEnabled("logs", opts) {
+		addon, err := NewLogsAddon(config, client, out, opts, q)
+		if err != nil {
+			return nil, err
+		}
+		registry["pods"] = addon
 	}
 
-	rookAddon, err := NewRookCephAddon(config, client, out, opts, q)
-	if err != nil {
-		return nil, err
-	}
-
-	registry := map[string]Addon{
-		"pods":                      logsAddon,
-		"ceph.rook.io/cephclusters": rookAddon,
+	if addonEnabled("rook", opts) {
+		addon, err := NewRookCephAddon(config, client, out, opts, q)
+		if err != nil {
+			return nil, err
+		}
+		registry["ceph.rook.io/cephclusters"] = addon
 	}
 
 	return registry, nil
+}
+
+func addonEnabled(name string, opts *Options) bool {
+	return opts.Addons == nil || slices.Contains(opts.Addons, name)
 }

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -28,6 +28,7 @@ type Options struct {
 	Kubeconfig string
 	Context    string
 	Namespaces []string
+	Addons     []string
 	Log        *zap.SugaredLogger
 }
 


### PR DESCRIPTION
This is useful when you don't want to gather pod logs or rook commands and debug logs from the nodes. It will be more useful when we have more addons, and allow making some addons optional.