### PR TITLE
Fix namespaces validation

### DIFF
--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -126,7 +126,9 @@ func (g *Gatherer) gatherAPIResources() error {
 	var namespaces []string
 
 	if len(g.opts.Namespaces) > 0 {
-		namespaces, err := g.lookupNamespaces()
+		var err error
+
+		namespaces, err = g.lookupNamespaces()
 		if err != nil {
 			// We cannot gather anything.
 			return err


### PR DESCRIPTION
Since b3c69124635, the found namespaces were not stored in the right namespaces list, so we always collected all namespaces.