### PR TITLE
Introduce  AddonBackend interface

### DIFF
--- a/pkg/gather/backend.go
+++ b/pkg/gather/backend.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: The kubectl-gather authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"net/http"
+
+	"k8s.io/client-go/rest"
+)
+
+type gatherBackend struct {
+	g *Gatherer
+}
+
+func (b *gatherBackend) Config() *rest.Config {
+	return b.g.config
+}
+
+func (b *gatherBackend) HTTPClient() *http.Client {
+	return b.g.httpClient
+}
+
+func (b *gatherBackend) Options() *Options {
+	return b.g.opts
+}
+
+func (b *gatherBackend) Output() *OutputDirectory {
+	return &b.g.output
+}
+
+func (b *gatherBackend) Queue(work WorkFunc) {
+	b.g.wq.Queue(work)
+}

--- a/pkg/gather/logs.go
+++ b/pkg/gather/logs.go
@@ -17,6 +17,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	logsName = "logs"
+)
+
 type LogsAddon struct {
 	client *kubernetes.Clientset
 	output *OutputDirectory
@@ -37,7 +41,7 @@ func (c containerInfo) String() string {
 }
 
 func init() {
-	registerAddon("logs", addonInfo{
+	registerAddon(logsName, addonInfo{
 		Resource:  "pods",
 		AddonFunc: NewLogsAddon,
 	})
@@ -54,7 +58,7 @@ func NewLogsAddon(config *rest.Config, httpClient *http.Client, out *OutputDirec
 		output: out,
 		opts:   opts,
 		q:      q,
-		log:    opts.Log.Named("logs"),
+		log:    opts.Log.Named(logsName),
 	}, nil
 }
 

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	rookName = "rook"
+)
+
 type RookAddon struct {
 	name   string
 	out    *OutputDirectory
@@ -30,7 +34,7 @@ type RookAddon struct {
 }
 
 func init() {
-	registerAddon("rook", addonInfo{
+	registerAddon(rookName, addonInfo{
 		Resource:  "ceph.rook.io/cephclusters",
 		AddonFunc: NewRookCephAddon,
 	})
@@ -43,12 +47,11 @@ func NewRookCephAddon(config *rest.Config, client *http.Client, out *OutputDirec
 	}
 
 	return &RookAddon{
-		name:   "rook",
 		out:    out,
 		opts:   opts,
 		q:      q,
 		client: clientSet,
-		log:    opts.Log.Named("rook"),
+		log:    opts.Log.Named(rookName),
 	}, nil
 }
 
@@ -86,7 +89,7 @@ func (a *RookAddon) gatherCommands(namespace string) {
 
 	a.log.Debugf("Using pod %q", tools.Name)
 
-	commands, err := a.out.CreateAddonDir(a.name, "commands")
+	commands, err := a.out.CreateAddonDir(rookName, "commands")
 	if err != nil {
 		a.log.Warnf("Cannot create commnads directory: %s", err)
 		return
@@ -185,7 +188,7 @@ func (a *RookAddon) gatherNodeLogs(namespace string, nodeName string, dataDir st
 
 	a.log.Debugf("Agent pod %q running in %.3f seconds", agent, time.Since(start).Seconds())
 
-	logs, err := a.out.CreateAddonDir(a.name, "logs", nodeName)
+	logs, err := a.out.CreateAddonDir(rookName, "logs", nodeName)
 	if err != nil {
 		a.log.Warnf("Cannot create logs directory: %s", err)
 		return
@@ -202,7 +205,7 @@ func (a *RookAddon) gatherNodeLogs(namespace string, nodeName string, dataDir st
 }
 
 func (a *RookAddon) createAgentPod(nodeName string, dataDir string) (*AgentPod, error) {
-	agent := NewAgentPod(a.name+"-"+nodeName, a.client, a.log)
+	agent := NewAgentPod(rookName+"-"+nodeName, a.client, a.log)
 	agent.Pod.Spec.NodeName = nodeName
 	agent.Pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 		{


### PR DESCRIPTION
Instead of passing 5 arguments to AddonFunc, pass a AddonBackend interface providing function to get the arguments.

The AddonBackend interface extends the Queuer interface so addons can embed the backend and use it to get options, output directory, and queue work. This simplifies the addon types, cleans up the code and make it more uniform.

The motivation is:
- make it easier to create new addons using simpler interfaces
- make addons code easier to understand since existing addons are the example for creating new addons.
- support concurrent gathering eliminating duplicate gathering for the same resource
- make it possible to move addons to a new package by depending on few public gather types and interfaces