### PR TITLE
Add shell completion helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ sudo install kubectl-gather /usr/local/bin
 rm kubectl-gather
 ```
 
+## Shell completion
+
+To enable shell completion install the
+[kubectl_complete-gather](kubectl_complete-gather) script in the PATH.
+
+```
+curl -L -O https://raw.githubusercontent.com/nirs/kubectl-gather/main/kubectl_complete-gather
+sudo install kubectl_complete-gather /usr/local/bin
+rm kubectl_complete-gather
+```
+
+> [!NOTE]
+> To enable shell completion when running as an `oc` plugin, the name of
+> the completion script must be `oc_complete-gather`.
+
 ## Gathering everything from the current cluster
 
 The simplest way is to gather everything from the current cluster named

--- a/kubectl_complete-gather
+++ b/kubectl_complete-gather
@@ -1,0 +1,4 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: The kubectl-gather authors
+# SPDX-License-Identifier: Apache-2.0
+exec kubectl gather __complete "$@"


### PR DESCRIPTION
The script can be copied to the PATH to enable shell completion.

Example completions

```
$ kubectl gather --[TAB]
--addons      (if specified, comma separated list of addons to enable (available addons: logs, pvcs, rook))
--contexts    (comma separated list of contexts to gather data from)
--directory   (directory for storing gathered data (default "gather.{timestamp}"))
--help        (help for gather)
--help        (help for kubectl gather)
--kubeconfig  (the kubeconfig file to use)
--namespaces  (if specified, comma separated list of namespaces to gather data from)
--remote      (run on the remote clusters (requires the "oc" command))
--verbose     (be more verbose)
```