### PR TITLE
WIP: Configurable version and image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,6 @@ permissions:
     contents: write
     packages: write
 
-env:
-  CGO_ENABLED: "0"
-
 jobs:
   release-matrix:
     name: Release binaries
@@ -35,3 +32,4 @@ jobs:
         goarch: ${{ matrix.goarch }}
         md5sum: FALSE
         compress_assets: OFF
+        build_command: make


### PR DESCRIPTION
Replace the hard coded version and image name using git describe.

When building from tag (e.g. v0.5.1) the version (0.5.1) and the image (quay.io/nirsof/gather:0.5.1) are injected into the executable and used to report the version and for the --remote option.

When building without a tag, the version includes the number of commits since the last tag, and a short git commit hash (v0.5.1-1-gcf79160).

The executable will use the image with the same version from the registry, so we need to push the image to the registry for testing the --remote option.

A new --version option added, reporting gather version.

A new --remote-image option added for setting the image for the --remote option. This is useful for testing the latest release image without pushing the image to the registry, for testing and image from your registry, or for using custom image on multiple clusters.

The gather script use the version option to generate /must-gather/version file instead of the hard-coded version.