### PR TITLE
Automate version management

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,6 @@ on:
     branches:
       - main
 
-env:
-  CGO_ENABLED: "0"
-
 jobs:
 
   lint:
@@ -44,13 +41,15 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Create build tag
+        run: git tag latest
       - name: Setup go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: false
       - name: Build binary
-        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make
 
   container:
     name: Build container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,10 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CGO_ENABLED: "0"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Create build tag
+        run: git tag latest
       - name: Setup multi-arch podman
         run: |
           sudo apt update

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,14 @@
 REGISTRY ?= quay.io
 REPO ?= nirsof
 IMAGE ?= gather
-VERSION ?= 0.6.0-dev
 
 package := github.com/nirs/kubectl-gather/pkg/gather
-image := $(REGISTRY)/$(REPO)/$(IMAGE):$(VERSION)
+
+# 0.5.1 when building from tag (release)
+# 0.5.1-1-gcf79160 when building without tag (development)
+version := $(shell git describe --tags | sed -e 's/^v//')
+
+image := $(REGISTRY)/$(REPO)/$(IMAGE):$(version)
 
 # % go build -ldflags="-help"
 #  -s	disable symbol table
@@ -15,7 +19,7 @@ image := $(REGISTRY)/$(REPO)/$(IMAGE):$(VERSION)
 #  -X 	definition
 #    	add string value definition of the form importpath.name=value
 ldflags := -s -w \
-	-X '$(package).Version=$(VERSION)' \
+	-X '$(package).Version=$(version)' \
 	-X '$(package).Image=$(image)'
 
 .PHONY: all kubectl-gather

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,17 @@
 REGISTRY ?= quay.io
 REPO ?= nirsof
 IMAGE ?= gather
-TAG ?= 0.6.0-dev
+VERSION ?= 0.6.0-dev
 
-image := $(REGISTRY)/$(REPO)/$(IMAGE):$(TAG)
+package := github.com/nirs/kubectl-gather/pkg/gather
+image := $(REGISTRY)/$(REPO)/$(IMAGE):$(VERSION)
 
 # % go build -ldflags="-help"
 #  -s	disable symbol table
 #  -w	disable DWARF generation
-ldflags := -s -w
+#  -X 	definition
+#    	add string value definition of the form importpath.name=value
+ldflags := -s -w -X '$(package).Version=$(VERSION)'
 
 .PHONY: all kubectl-gather
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ image := $(REGISTRY)/$(REPO)/$(IMAGE):$(VERSION)
 #  -w	disable DWARF generation
 #  -X 	definition
 #    	add string value definition of the form importpath.name=value
-ldflags := -s -w -X '$(package).Version=$(VERSION)'
+ldflags := -s -w \
+	-X '$(package).Version=$(VERSION)' \
+	-X '$(package).Image=$(image)'
 
 .PHONY: all kubectl-gather
 

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
 
-const remoteDefaultImage = "quay.io/nirsof/gather:0.5.1"
+	"github.com/nirs/kubectl-gather/pkg/gather"
+)
 
 func remoteGather(clusters []*clusterConfig) {
 	start := time.Now()
@@ -87,7 +87,7 @@ func mustGatherCommand(context string, directory string) *exec.Cmd {
 	args := []string{
 		"adm",
 		"must-gather",
-		"--image=" + remoteDefaultImage,
+		"--image=" + gather.Image,
 		"--context=" + context,
 		"--dest-dir=" + directory,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ var example = `  # Gather data from all namespaces in current context in my-kube
 var rootCmd = &cobra.Command{
 	Use:     "kubectl-gather",
 	Short:   "Gather data from clusters",
+	Version: gather.Version,
 	Example: example,
 	Annotations: map[string]string{
 		cobra.CommandDisplayNameAnnotation: "kubectl gather",
@@ -86,6 +87,9 @@ func init() {
 		"run on the remote clusters (requires the \"oc\" command)")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
 		"be more verbose")
+
+	// Use plain, machine friendly version string.
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }
 
 func runGather(cmd *cobra.Command, args []string) {

--- a/gather
+++ b/gather
@@ -6,6 +6,7 @@
 base="/must-gather"
 
 mkdir -p "$base"
-printf "gather\n0.1.0\n" > "$base/version"
 
-/usr/bin/kubectl-gather --directory "$base" "$@"
+printf "gather\n$(kubectl-gather --version)\n" > "$base/version"
+
+kubectl-gather --directory "$base" "$@"

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -34,6 +34,7 @@ const listResourcesLimit = 100
 
 // Replaced during build with actual values.
 var Version = "latest"
+var Image = "quay.io/nirsof/gather:latest"
 
 type Options struct {
 	Kubeconfig string

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -32,6 +32,9 @@ import (
 // TODO: Needs more testing to find the optimal value.
 const listResourcesLimit = 100
 
+// Replaced during build with actual values.
+var Version = "latest"
+
 type Options struct {
 	Kubeconfig string
 	Context    string


### PR DESCRIPTION
- Eliminate duplicate builds
- Add --version flag reporting the injecting version
- Use actual version in /must-gather/version
- Use the current image version by injecting the image into the executable 
- Generate the version using `git describe` and inject it into the executable
