### PR TITLE
Cleaner multi-arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,15 @@ ldflags := -s -w \
 
 all: kubectl-gather
 
-container:
+container: container-amd64 container-arm64
+	podman manifest create --amend $(image)
+	podman manifest add $(image) $(image)-amd64
+	podman manifest add $(image) $(image)-arm64
+
+container-%:
 	podman build \
-		--platform=linux/amd64,linux/arm64 \
-		--manifest $(image) \
+		--platform=linux/$* \
+		--tag $(image)-$* \
 		--build-arg ldflags="$(ldflags)" \
 		.
 


### PR DESCRIPTION
Create the specific tagged arch images separately and then create a manifest with both images.

This makes the output much easier to manage. The time to create seems similar to the one command build.