### PR TITLE
Machine friendly logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,31 @@ $ du -sh gather.*
 8.8M	gather.resources
 ```
 
+## Integrating with other programs
+
+When running the *kubectl gather* from another program you may want to
+use JSON logs to extract certain fileds from the gather logs.
+
+Example: extracting the "msg" field from gather JSON logs:
+
+```
+% kubectl gather --kubeconfig e2e/clusters.yaml \
+                 --contexts kind-c1,kind-c2 \
+                 --log-format json 2>&1 | jq -r .msg
+Using kubeconfig "e2e/clusters.yaml"
+Gathering from all namespaces
+Using all addons
+Storing data in "gather.20250114190449"
+Gathering from cluster "kind-c1"
+Gathering from cluster "kind-c2"
+Gathered 321 resources from cluster "kind-c2" in 0.137 seconds
+Gathered 338 resources from cluster "kind-c1" in 0.140 seconds
+Gathered 659 resources from 2 clusters in 0.140 seconds
+```
+
+To extract also debug level logs you can use the `gather.log` file from
+the gather directory.
+
 ## Similar projects
 
 - [must-gather](https://github.com/openshift/must-gather) - similar tool

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -23,3 +23,17 @@ func TestGather(t *testing.T) {
 	}
 	// XXX verify gathered data.
 }
+
+func TestJSONLogs(t *testing.T) {
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names(), ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--directory", "test-json-logs.out",
+		"--log-format", "json",
+	)
+	if err := commands.LogStderr(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+	// XXX verify gathered data.
+}


### PR DESCRIPTION
Add --log-format with "text" (default) and "json" options. When using
text format we disable caller info and stacktraces in the console logs
bug keep them enabled in the log file. When using json logs we enable
everything so a program can consume what it needs.

Replace the DevelopmentConfig with ProductionConfig that have nicer keys
(e.g. "level" instead of "L").

Example text logs (default):

    % ./kubectl-gather --contexts dr1,dr2,hub --log-format text -d gather.text
    2025-01-14T16:33:01.901+0200        INFO    gather  Using kubeconfig "/Users/nir/.kube/config"
    2025-01-14T16:33:01.904+0200        INFO    gather  Gathering from all namespaces
    2025-01-14T16:33:01.904+0200        INFO    gather  Using all addons
    2025-01-14T16:33:01.904+0200        INFO    gather  Gathering from cluster "dr1"
    2025-01-14T16:33:01.904+0200        INFO    gather  Gathering from cluster "dr2"
    2025-01-14T16:33:01.904+0200        INFO    gather  Gathering from cluster "hub"
    2025-01-14T16:33:03.445+0200        INFO    gather  Gathered 1167 resources from cluster "hub" in 1.541 seconds
    2025-01-14T16:33:04.397+0200        INFO    gather  Gathered 1294 resources from cluster "dr2" in 2.493 seconds
    2025-01-14T16:33:04.399+0200        INFO    gather  Gathered 1258 resources from cluster "dr1" in 2.495 seconds
    2025-01-14T16:33:04.399+0200        INFO    gather  Gathered 3719 resources from 3 clusters in 2.495 seconds

Example json logs:

    % ./kubectl-gather --contexts dr1,dr2,hub --log-format json -d gather.json
    {"level":"INFO","ts":"2025-01-14T16:33:11.725+0200","logger":"gather","msg":"Using kubeconfig \"/Users/nir/.kube/config\""}
    {"level":"INFO","ts":"2025-01-14T16:33:11.727+0200","logger":"gather","msg":"Gathering from all namespaces"}
    {"level":"INFO","ts":"2025-01-14T16:33:11.727+0200","logger":"gather","msg":"Using all addons"}
    {"level":"INFO","ts":"2025-01-14T16:33:11.727+0200","logger":"gather","msg":"Gathering from cluster \"dr1\""}
    {"level":"INFO","ts":"2025-01-14T16:33:11.727+0200","logger":"gather","msg":"Gathering from cluster \"dr2\""}
    {"level":"INFO","ts":"2025-01-14T16:33:11.727+0200","logger":"gather","msg":"Gathering from cluster \"hub\""}
    {"level":"INFO","ts":"2025-01-14T16:33:13.134+0200","logger":"gather","msg":"Gathered 1167 resources from cluster \"hub\" in 1.408 seconds"}
    {"level":"INFO","ts":"2025-01-14T16:33:14.439+0200","logger":"gather","msg":"Gathered 1298 resources from cluster \"dr2\" in 2.712 seconds"}
    {"level":"INFO","ts":"2025-01-14T16:33:14.445+0200","logger":"gather","msg":"Gathered 1262 resources from cluster \"dr1\" in 2.718 seconds"}
    {"level":"INFO","ts":"2025-01-14T16:33:14.445+0200","logger":"gather","msg":"Gathered 3727 resources from 3 clusters in 2.718 seconds"}

Fixes #68