### PR TITLE
Add lint target and config file

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: The kubectl-gather authors
+# SPDX-License-Identifier: Apache-2.0
+
+run:
+  deadline: 5m
+
+linters:
+  enable:
+    - errcheck
+    - goconst
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - nolintlint
+    - staticcheck
+    - unused
+    # TODO: enable after fixing issues
+    #- gocritic
+    #- gosec
+    #- misspell
+    #- stylecheck
+    #- unconvert
+  fast: false

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ldflags := -s -w \
 
 all: kubectl-gather
 
+lint:
+	golangci-lint run ./...
+	cd e2e && golangci-lint run ./...
+
 container:
 	podman build \
 		--platform=linux/amd64,linux/arm64 \


### PR DESCRIPTION
Import enabled linters from Cobra.

The new inters revealed few issues, so some linters disabled until we fix the issues.