### PR TITLE
Rename ci workflow to test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-name: CI
+name: Test
 
 on:
   pull_request:


### PR DESCRIPTION
Describes better the purpose of the workflow, and the name "Test" is more consistent with "Release".