### PR TITLE
Increase queue size

### DIFF
--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -100,7 +100,7 @@ func New(config *rest.Config, directory string, opts Options) (*Gatherer, error)
 	}
 
 	// TODO: make configurable
-	wq := NewWorkQueue(6, 500)
+	wq := NewWorkQueue(6, 2000)
 
 	g := &Gatherer{
 		config:     config,


### PR DESCRIPTION
Recently I see random deadlocks, both in small and big clusters.

Example from last run:

    % grep -A1 -E '^goroutine.+chan send' deadlock.log
    goroutine 412 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)
    --
    goroutine 411 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)
    --
    goroutine 415 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)
    --
    goroutine 413 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)
    --
    goroutine 414 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)
    --
    goroutine 416 [chan send, 3 minutes]:
    github.com/nirs/kubectl-gather/pkg/gather.(*WorkQueue).Queue(...)

We have 6 workers, all of them are blocked sending to the queue channel. This can happen only when the channel is full. Increase the size from 500 to 2000.

This happens when gathering large number of namespaces:

    2025-03-27T21:10:31.795+0200    INFO    gather/gather.go:24     Gather
    namespaces ["openshift-dr-ops" "openshift-dr-system" "openshift-gitops"
    "openshift-operators" "test-appset-deploy-cephfs" "test-appset-dep

Every namespace has large number of API resources:

    2025-03-27T21:10:33.460+0200    DEBUG   prsurve-ibm-h1
    gather/gather.go:218    Listed 247 api resources in 0.302 seconds

    2025-03-27T21:10:33.935+0200    DEBUG   prsurve-ibm-c2
    gather/gather.go:218    Listed 211 api resources in 0.305 seconds

    2025-03-27T21:10:33.984+0200    DEBUG   prsurve-ibm-c1
    gather/gather.go:218    Listed 211 api resources in 0.313 seconds

And for each resource we queue gatherResource() call for every namespace:

	resources, err := g.listAPIResources()
	if err != nil {
		// We cannot gather anything.
		return fmt.Errorf("cannot list api resources: %s", err)
	}

	for i := range resources {
		r := &resources[i]
		for j := range namespaces {
			namespace := namespaces[j]
			g.wq.Queue(func() error {
				g.gatherResources(r, namespace)
				return nil
			})
		}
	}

Increase the queue from 500 to 2000 to make this less likely. We need to think about a better way to queue work.

Fixes #80 