### PR TITLE
New gather pipeline

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,57 @@
+# kubectl-gather internals
+
+## Pipeline
+
+kubectl-gather fetch and process data in a 3 steps pipeline:
+
+```
+prepare --> gather --> inpsect
+```
+
+### Prepare step
+
+This step runs in the goroutine calling Gather(). This step includes:
+
+1. Looking up available namespaces - if no namespaces is given, we have list
+   with one iteme, the special empty namespace, gathering resources from all
+   namespaces.
+1. Looking up API resources.
+1. Queuing gatherResources(resource, namespace) for every resource and namespace in the gatherWorkqueu.
+1. Close the gatherWorkqueue
+
+This step ends when all work was queued in the resources work queue. Since the queue is unbuffered, this ends when the last gatherResources() call was queued.
+
+### Gather step
+
+This steps run in the gatherWorkqueue goroutines.
+
+The workers pick up work functions from the queue and run them.
+
+Running gather resources steps:
+
+1. List all resources with specified type and namespaces
+1. Dump every resource to the output directory
+1. If an addon is registered for the resource, call addon.Inspect(). Inspecting
+   a resource may fetch new resources from the cluster, or queue more work in
+   the inspectWorkqueue.
+1. When all workers are done, close the inspectWorkqueue
+
+Workers cannot queue more work in the gatherWorkqueue. All work must be queued in prepare step.
+
+The workers exit when there is no more work to do.
+
+### Inspect step
+
+This step runs in the inspectWorkqueue.
+
+The workers running in this step pick up work functions from the queue and run them.
+
+Work done in the inspect queue depends on the addon. Examples are:
+
+- Copy logs from containers
+- Running commands in agenet pod
+- Copy logs from nodes
+
+Workers cannot queue more work in the inspectWorkqueue. All work must be queued in gather step.
+
+The workers exit when there is no more work to do.

--- a/pkg/gather/backend.go
+++ b/pkg/gather/backend.go
@@ -12,7 +12,8 @@ import (
 )
 
 type gatherBackend struct {
-	g *Gatherer
+	g  *Gatherer
+	wq *WorkQueue
 }
 
 func (b *gatherBackend) Config() *rest.Config {
@@ -32,12 +33,9 @@ func (b *gatherBackend) Output() *OutputDirectory {
 }
 
 func (b *gatherBackend) Queue(work WorkFunc) {
-	b.g.wq.Queue(work)
+	b.wq.Queue(work)
 }
 
 func (b *gatherBackend) GatherResource(gvr schema.GroupVersionResource, name types.NamespacedName) {
-	b.g.wq.Queue(func() error {
-		b.g.gatherResource(gvr, name)
-		return nil
-	})
+	b.g.gatherResource(gvr, name)
 }

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -52,10 +52,7 @@ func (a *RookAddon) Inspect(cephcluster *unstructured.Unstructured) error {
 	namespace := cephcluster.GetNamespace()
 	a.log.Debugf("Inspecting cephcluster \"%s/%s\"", namespace, cephcluster.GetName())
 
-	a.Queue(func() error {
-		a.gatherCommands(namespace)
-		return nil
-	})
+	a.gatherCommands(namespace)
 
 	if a.logCollectorEnabled(cephcluster) {
 		dataDir, err := a.dataDirHostPath(cephcluster)
@@ -64,10 +61,7 @@ func (a *RookAddon) Inspect(cephcluster *unstructured.Unstructured) error {
 			return nil
 		}
 
-		a.Queue(func() error {
-			a.gatherLogs(namespace, dataDir)
-			return nil
-		})
+		a.gatherLogs(namespace, dataDir)
 	}
 
 	return nil
@@ -99,7 +93,10 @@ func (a *RookAddon) gatherCommands(namespace string) {
 		return nil
 	})
 
-	a.gatherCommand(rc, "ceph", "status")
+	a.Queue(func() error {
+		a.gatherCommand(rc, "ceph", "status")
+		return nil
+	})
 }
 
 func (a *RookAddon) gatherCommand(rc *RemoteCommand, command ...string) {

--- a/pkg/gather/workqueue.go
+++ b/pkg/gather/workqueue.go
@@ -17,29 +17,30 @@ type WorkQueue struct {
 	wg      sync.WaitGroup
 	mutex   sync.Mutex
 	err     error
+	closed  bool
 }
 
-func NewWorkQueue(workers int, size int) *WorkQueue {
+func NewWorkQueue(workers int) *WorkQueue {
 	return &WorkQueue{
-		queue:   make(chan WorkFunc, size),
+		queue:   make(chan WorkFunc),
 		workers: workers,
 	}
 }
 
 func (q *WorkQueue) Queue(work WorkFunc) {
-	q.wg.Add(1)
 	q.queue <- work
 }
 
 func (q *WorkQueue) Start() {
 	for i := 0; i < q.workers; i++ {
+		q.wg.Add(1)
 		go func() {
+			defer q.wg.Done()
 			for work := range q.queue {
 				err := work()
 				if err != nil {
 					q.setFirstError(err)
 				}
-				q.wg.Done()
 			}
 		}()
 	}
@@ -48,6 +49,16 @@ func (q *WorkQueue) Start() {
 func (q *WorkQueue) Wait() error {
 	q.wg.Wait()
 	return q.firstError()
+}
+
+func (q *WorkQueue) Close() {
+	// Closing closed channel panics, so we must call it exactly once.
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	if !q.closed {
+		close(q.queue)
+		q.closed = true
+	}
 }
 
 func (q *WorkQueue) firstError() error {


### PR DESCRIPTION
Eliminate the deadlocks and uncontrolled memory usage by switching to
unbuffered channels. When queuing work, the function returns when one of
the workers picked up the work. If all workers are busy, the caller is
blocked until a worker is available.

Previously we had one work queue, and anyone could queue work on the
queue for later processing without any limit. This caused deadlocks
when al workers are trying to queue work and the queue becomes full.

The new pipeline splits the work to 3 steps:

    prepare -> gather -> inspect

Pipeline steps:

1. prepare: look up namespaces and api resources, and queue work on the
   gather work queue.
2. gather: run work functions queued by the prepare step, and queue work
   on the inspect work queue
3. inspect: run work functions queued by the gather step.

Since every step queues work on the next step queue, workers cannot
deadlock.

Waiting for completion is simpler and more robust now:

- When the prepare step completes, we know that no more work can be
  queued in the gather work queue, so we close it.
- When the gather work queue completes, we know that no more work can be
  queued in the inspect work queue so we close it.
- When the inspect work queue completes, we know that all work was
  finished and we can return.

The limitation with the new pipeline is that you cannot queue more work
from a queued work function on the same queue. In every step you must
get all the data you need for queueing work on the next step. For
example when inspecting pods, we must get all the containers from the
pod, and queue gather log function on the inspect work queue. This
limitation is not an issue for the current code.

Previously we had one work queue with 6 workers. Now we use 2 work
queues with 6 workers in each. Testing shows that number of workers does
not affect memory usage significantly, but it decrease the time to
gather.

Comparing to previous version when gathering entire ODF managed cluster,
collecting 3.1 GiB of data. The new version is 1.3 times faster but use
1.13 times more memory.

| version | maximum RSS | time      |
|---------|-------------|-----------|
| before  |   130.9 MiB |   228.6 s |
| after   |   148.0 MiB |   173.3 s |

Another advantage of the new pipeline is that work queues are closed
when Gather() returns. Previously we leaked the goroutines until the
process terminates. This is not an issue for kubectl-gather command, but
it is an issue when using kubectl-gather as a library, for example
gathering data after every test step in ramenctl.
