### PR TITLE
Build and push container as part of the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ permissions:
   packages: write
 
 jobs:
-  release-matrix:
+  release-binaries:
     name: Release binaries
     runs-on: ubuntu-latest
     strategy:
@@ -34,3 +34,22 @@ jobs:
         md5sum: FALSE
         compress_assets: OFF
         build_command: make
+  release-container:
+    name: Release container
+    runs-on: ubuntu-24.04  # for recent enough podman
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Setup multi-arch podman
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-user-static podman
+          podman version
+      - name: Login to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Build and push container
+        run: make container-push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ on:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
   release-matrix:


### PR DESCRIPTION
Add a release-container job building and pushing the container to avoid manual builds.

Preview:
- https://github.com/nirs/kubectl-gather/releases/tag/v0.8.1-pre1
- https://quay.io/repository/nirsof/gather?tab=tags

Fixes #42 