### PR TITLE
e2e: Keep generated files under out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /kubectl-gather
 /gather/
 /e2e/e2e
+/e2e/out

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -7,9 +7,7 @@ clusters: e2e
 test: clusters
 	go test . -v -count=1
 
-clean:
+clean: e2e
 	./e2e delete
-	rm -rf test-*.out
-	rm -f kind-*.yaml
-	rm -f clusters.yaml
+	rm -rf out
 	rm -f e2e

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -16,7 +16,7 @@ func TestGather(t *testing.T) {
 		executable,
 		"--contexts", strings.Join(clusters.Names(), ","),
 		"--kubeconfig", clusters.Kubeconfig(),
-		"--directory", "test-gather.out",
+		"--directory", "out/test-gather",
 	)
 	if err := commands.LogStderr(cmd); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
@@ -29,7 +29,7 @@ func TestJSONLogs(t *testing.T) {
 		executable,
 		"--contexts", strings.Join(clusters.Names(), ","),
 		"--kubeconfig", clusters.Kubeconfig(),
-		"--directory", "test-json-logs.out",
+		"--directory", "out/test-json-logs",
 		"--log-format", "json",
 	)
 	if err := commands.LogStderr(cmd); err != nil {


### PR DESCRIPTION
We want to add many more tests and keeping all the files and directories in the e2e/ directory is too messy. All the files are created at out/ now.

Example content after running the tests:

    % tree -L2 out
    out
    ├── kind-c1.yaml
    ├── kind-c2.yaml
    ├── kubeconfig.yaml
    ├── test-gather
    │   ├── gather.log
    │   ├── kind-c1
    │   └── kind-c2
    └── test-json-logs
        ├── gather.log
        ├── kind-c1
        └── kind-c2