### PR TITLE
e2e: Deploy applications for testing

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,11 +1,41 @@
+deploy undeploy: export KUBECONFIG = out/kubeconfig.yaml
+
 e2e:
 	go build -o $@ ./cmd
+
+test: clusters deploy
+	go test . -v -count=1
 
 clusters: e2e
 	./e2e create
 
-test: clusters
-	go test . -v -count=1
+deploy:
+	# Deploy common deployment on both clusters.
+	kubectl apply -k testdata/common --context kind-c1
+	kubectl apply -k testdata/common --context kind-c2
+	# Deploy c1 deployment on c1.
+	kubectl apply -k testdata/c1 --context kind-c1
+	# Deploy c2 deployment on c2.
+	kubectl apply -k testdata/c2 --context kind-c2
+	# Wait for all deployments.
+	kubectl rollout status deploy common-busybox -n test-common --context kind-c1
+	kubectl rollout status deploy common-busybox -n test-common --context kind-c2
+	kubectl rollout status deploy c1-busybox -n test-c1 --context kind-c1
+	kubectl rollout status deploy c2-busybox -n test-c2 --context kind-c2
+
+undeploy:
+	# Delete common deployment on both clusters.
+	kubectl delete -k testdata/common --context kind-c1 --ignore-not-found --wait=false
+	kubectl delete -k testdata/common --context kind-c2 --ignore-not-found --wait=false
+	# Delete c1 deployment on c1.
+	kubectl delete -k testdata/c1 --context kind-c1 --ignore-not-found --wait=false
+	# Delete c2 deployment on c2.
+	kubectl delete -k testdata/c2 --context kind-c2 --ignore-not-found --wait=false
+	# Wait for all deletions.
+	kubectl wait ns test-common --for delete --context kind-c1
+	kubectl wait ns test-common --for delete --context kind-c2
+	kubectl wait ns test-c1 --for delete --context kind-c1
+	kubectl wait ns test-c2 --for delete --context kind-c2
 
 clean: e2e
 	./e2e delete

--- a/e2e/testdata/base/deploy.yaml
+++ b/e2e/testdata/base/deploy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: quay.io/nirsof/busybox:stable
+        name: busybox
+        command:
+        - sh
+        - -c
+        - |
+          trap exit TERM
+          while true; do
+              echo $(date) | tee -a /mnt/test/log
+              sync
+              sleep 10 &
+              wait
+          done
+        volumeMounts:
+        - name: pvc1
+          mountPath: /mnt/test
+      volumes:
+      - name: pvc1
+        persistentVolumeClaim:
+          claimName: pvc1

--- a/e2e/testdata/base/kustomization.yaml
+++ b/e2e/testdata/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+  - pv.yaml
+  - ns.yaml
+  - pvc.yaml
+  - deploy.yaml

--- a/e2e/testdata/base/ns.yaml
+++ b/e2e/testdata/base/ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/e2e/testdata/base/pv.yaml
+++ b/e2e/testdata/base/pv.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv1
+spec:
+  storageClassName: standard
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: MOUNT_PATH

--- a/e2e/testdata/base/pvc.yaml
+++ b/e2e/testdata/base/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc1
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/e2e/testdata/c1/kustomization.yaml
+++ b/e2e/testdata/c1/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base
+namePrefix: c1-
+namespace: test-c1
+patches:
+  # Patch the mount point to match the name prefix.
+  - target:
+      kind: PersistentVolume
+      name: pv1
+    patch: |-
+      - op: replace
+        path: /spec/hostPath/path
+        value: /mnt/c1-pv1

--- a/e2e/testdata/c2/kustomization.yaml
+++ b/e2e/testdata/c2/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base
+namePrefix: c2-
+namespace: test-c2
+patches:
+  # Patch the mount point to match the name prefix.
+  - target:
+      kind: PersistentVolume
+      name: pv1
+    patch: |-
+      - op: replace
+        path: /spec/hostPath/path
+        value: /mnt/c2-pv1

--- a/e2e/testdata/common/kustomization.yaml
+++ b/e2e/testdata/common/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base
+namePrefix: common-
+namespace: test-common
+patches:
+  # Patch the mount point to match the name prefix.
+  - target:
+      kind: PersistentVolume
+      name: pv1
+    patch: |-
+      - op: replace
+        path: /spec/hostPath/path
+        value: /mnt/common-pv1


### PR DESCRIPTION
We want to have known data for testing that will not change behind our
back when k8s or kind changes the way stuff is deployed.

We deploy 3 applications:
- common-busybox in namespace test-common, on both clusters
- c1-busybox in namespace test-c1, on cluster c1
- c2-busybox in namespace test-c2, on cluster c2

The deployment it trivial busybox deployment with one pvc.

New deploy and undeploy targets can be used to work on the deployment.

## Example gathered data

```console
% tree -L3 out/test-gather
out/test-gather
├── gather.log
├── kind-c1
│   ├── cluster
│   │   ├── apiregistration.k8s.io
│   │   ├── flowcontrol.apiserver.k8s.io
│   │   ├── namespaces
│   │   ├── networking.k8s.io
│   │   ├── nodes
│   │   ├── persistentvolumes
│   │   ├── rbac.authorization.k8s.io
│   │   ├── scheduling.k8s.io
│   │   └── storage.k8s.io
│   └── namespaces
│       ├── default
│       ├── kube-node-lease
│       ├── kube-public
│       ├── kube-system
│       ├── local-path-storage
│       ├── test-c1
│       └── test-common
└── kind-c2
    ├── cluster
    │   ├── apiregistration.k8s.io
    │   ├── flowcontrol.apiserver.k8s.io
    │   ├── namespaces
    │   ├── networking.k8s.io
    │   ├── nodes
    │   ├── persistentvolumes
    │   ├── rbac.authorization.k8s.io
    │   ├── scheduling.k8s.io
    │   └── storage.k8s.io
    └── namespaces
        ├── default
        ├── kube-node-lease
        ├── kube-public
        ├── kube-system
        ├── local-path-storage
        ├── test-c2
        └── test-common
```

## Example application namespace

```console
% tree out/test-gather/kind-c1/namespaces/test-c1
out/test-gather/kind-c1/namespaces/test-c1
├── apps
│   ├── deployments
│   │   └── c1-busybox.yaml
│   └── replicasets
│       └── c1-busybox-5dfcb75c76.yaml
├── configmaps
│   └── kube-root-ca.crt.yaml
├── events.k8s.io
│   └── events
│       ├── c1-busybox-5dfcb75c76-rmzm6.1854a1289c108b79.yaml
│       ├── c1-busybox-5dfcb75c76-rmzm6.1854a128b2070046.yaml
│       ├── c1-busybox-5dfcb75c76-rmzm6.1854a12a6c38fc2c.yaml
│       ├── c1-busybox-5dfcb75c76-rmzm6.1854a12a6cf55dc3.yaml
│       ├── c1-busybox-5dfcb75c76-rmzm6.1854a12a70f6db19.yaml
│       ├── c1-busybox-5dfcb75c76.1854a1285fefd891.yaml
│       ├── c1-busybox.1854a1285fdd3082.yaml
│       └── c1-pvc1.1854a1285f6a461d.yaml
├── persistentvolumeclaims
│   └── c1-pvc1.yaml
├── pods
│   ├── c1-busybox-5dfcb75c76-rmzm6
│   │   └── busybox
│   │       └── current.log
│   └── c1-busybox-5dfcb75c76-rmzm6.yaml
└── serviceaccounts
    └── default.yaml
```

Example cluster pvs

```console
% tree out/test-gather/kind-c1/cluster/persistentvolumes
out/test-gather/kind-c1/cluster/persistentvolumes
├── c1-pv1.yaml
└── common-pv1.yaml
```
