### PR TITLE
e2e: Add e2e validation and additional tests

### DIFF
--- a/e2e/clusters/clusters.go
+++ b/e2e/clusters/clusters.go
@@ -14,15 +14,14 @@ import (
 )
 
 const (
+	C1 = "kind-c1"
+	C2 = "kind-c2"
+
 	outdir     = "out"
 	kubeconfig = "kubeconfig.yaml"
 )
 
-var names = []string{"kind-c1", "kind-c2"}
-
-func Names() []string {
-	return names
-}
+var Names = []string{C1, C2}
 
 func Kubeconfig() string {
 	return filepath.Join(outdir, kubeconfig)
@@ -33,7 +32,7 @@ func Create() error {
 	if err := os.MkdirAll(outdir, 0o700); err != nil {
 		return err
 	}
-	if err := execute(createCluster, names); err != nil {
+	if err := execute(createCluster, Names); err != nil {
 		return err
 	}
 	if err := createKubeconfig(); err != nil {
@@ -45,7 +44,7 @@ func Create() error {
 
 func Delete() error {
 	log.Print("Deleting clusters")
-	if err := execute(deleteCluster, names); err != nil {
+	if err := execute(deleteCluster, Names); err != nil {
 		return err
 	}
 	_ = os.Remove(Kubeconfig())
@@ -111,7 +110,7 @@ func deleteCluster(name string) error {
 func createKubeconfig() error {
 	log.Printf("Creating kubconfigs %q", Kubeconfig())
 	var configs []string
-	for _, name := range names {
+	for _, name := range Names {
 		configs = append(configs, clusterKubeconfig(name))
 	}
 	cmd := exec.Command("kubectl", "config", "view", "--flatten")

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -2,38 +2,312 @@ package e2e_test
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/nirs/kubectl-gather/e2e/clusters"
 	"github.com/nirs/kubectl-gather/e2e/commands"
+	"github.com/nirs/kubectl-gather/e2e/validate"
 )
 
 const executable = "../kubectl-gather"
 
+var (
+	commonClusterResources = []string{
+		"cluster/namespaces/test-common.yaml",
+	}
+
+	commonNamespacedResources = []string{
+		"namespaces/test-common/persistentvolumeclaims/common-pvc1.yaml",
+		"namespaces/test-common/pods/common-busybox-*.yaml",
+		"namespaces/test-common/apps/deployments/common-busybox.yaml",
+		"namespaces/test-common/apps/replicasets/common-busybox-*.yaml",
+		"namespaces/test-common/configmaps/kube-root-ca.crt.yaml",
+		"namespaces/test-common/serviceaccounts/default.yaml",
+	}
+
+	commonLogResources = []string{
+		"namespaces/test-common/pods/common-busybox-*/busybox/current.log",
+	}
+
+	commonPVCResources = []string{
+		"cluster/persistentvolumes/common-pv1.yaml",
+	}
+
+	c1ClusterResources = []string{
+		"cluster/namespaces/test-c1.yaml",
+	}
+
+	c1NamespaceResources = []string{
+		"namespaces/test-c1/persistentvolumeclaims/c1-pvc1.yaml",
+		"namespaces/test-c1/pods/c1-busybox-*.yaml",
+		"namespaces/test-c1/apps/deployments/c1-busybox.yaml",
+		"namespaces/test-c1/apps/replicasets/c1-busybox-*.yaml",
+		"namespaces/test-c1/configmaps/kube-root-ca.crt.yaml",
+		"namespaces/test-c1/serviceaccounts/default.yaml",
+	}
+
+	c1LogResources = []string{
+		"namespaces/test-c1/pods/c1-busybox-*/busybox/current.log",
+	}
+
+	c1PVCResources = []string{
+		"cluster/persistentvolumes/c1-pv1.yaml",
+	}
+
+	c2ClusterResources = []string{
+		"cluster/namespaces/test-c2.yaml",
+	}
+
+	c2NamespaceResources = []string{
+		"namespaces/test-c2/persistentvolumeclaims/c2-pvc1.yaml",
+		"namespaces/test-c2/pods/c2-busybox-*.yaml",
+		"namespaces/test-c2/apps/deployments/c2-busybox.yaml",
+		"namespaces/test-c2/apps/replicasets/c2-busybox-*.yaml",
+		"namespaces/test-c2/configmaps/kube-root-ca.crt.yaml",
+		"namespaces/test-c2/serviceaccounts/default.yaml",
+	}
+
+	c2LogResources = []string{
+		"namespaces/test-c2/pods/c2-busybox-*/busybox/current.log",
+	}
+
+	c2PVCResources = []string{
+		"cluster/persistentvolumes/c2-pv1.yaml",
+	}
+
+	defaultPVCResources = []string{
+		"cluster/storage.k8s.io/storageclasses/standard.yaml",
+	}
+)
+
 func TestGather(t *testing.T) {
+	outputDir := "out/test-gather"
+
 	cmd := exec.Command(
 		executable,
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--kubeconfig", clusters.Kubeconfig(),
-		"--directory", "out/test-gather",
+		"--directory", outputDir,
 	)
 	if err := commands.Run(cmd); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
-	// XXX verify gathered data.
+
+	validate.Exists(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+	validate.Exists(t, outputDir, clusters.Names, commonLogResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1LogResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2LogResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2NamespaceResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2LogResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1NamespaceResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1LogResources)
 }
 
-func TestJSONLogs(t *testing.T) {
+func TestGatherEmptyNamespaces(t *testing.T) {
+	outputDir := "out/test-gather-empty-namespaces"
+
 	cmd := exec.Command(
 		executable,
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--kubeconfig", clusters.Kubeconfig(),
-		"--directory", "out/test-json-logs",
+		"--namespaces=", "",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+
+	// TODO: Empty namespace should result in gathering no resources.
+	validate.Exists(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+	validate.Exists(t, outputDir, clusters.Names, commonLogResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1LogResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2LogResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2NamespaceResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2LogResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1NamespaceResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1LogResources)
+}
+
+func TestGatherSpecificNamespaces(t *testing.T) {
+	outputDir := "out/test-gather-specific-namespaces"
+
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--namespaces", "test-common,test-c1",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+
+	validate.Exists(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+}
+
+func TestGatherAddonsLogs(t *testing.T) {
+	outputDir := "out/test-gather-addons-logs"
+
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--namespaces", "test-common,test-c1,test-c2",
+		"--addons", "logs",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+
+	validate.Exists(t, outputDir, clusters.Names, commonLogResources)
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1LogResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2LogResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+
+	validate.Missing(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Missing(t, outputDir, clusters.Names, commonPVCResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C1}, c1PVCResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2PVCResources)
+}
+
+func TestGatherAddonsPVCs(t *testing.T) {
+	outputDir := "out/test-gather-addons-pvcs"
+
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--namespaces", "test-common,test-c1,test-c2",
+		"--addons", "pvcs",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+
+	validate.Exists(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonPVCResources)
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2PVCResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+
+	validate.Missing(t, outputDir, clusters.Names, commonLogResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c1LogResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2LogResources)
+}
+
+func TestGatherAddonsEmpty(t *testing.T) {
+	outputDir := "out/test-gather-addons-empty"
+
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--namespaces", "test-common,test-c1,test-c2",
+		"--addons=",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err != nil {
+		t.Errorf("kubectl-gather failed: %s", err)
+	}
+
+	validate.Missing(t, outputDir, clusters.Names, defaultPVCResources)
+	validate.Missing(t, outputDir, clusters.Names, commonLogResources)
+	validate.Missing(t, outputDir, clusters.Names, commonPVCResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C1}, c1LogResources)
+	validate.Missing(t, outputDir, []string{clusters.C1}, c1PVCResources)
+
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2LogResources)
+	validate.Missing(t, outputDir, []string{clusters.C2}, c2PVCResources)
+
+	validate.Exists(t, outputDir, clusters.Names, commonClusterResources)
+	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
+
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
+}
+
+func TestJSONLogs(t *testing.T) {
+	outputDir := "out/test-json-logs"
+	logPath := filepath.Join(outputDir, "gather.log")
+
+	cmd := exec.Command(
+		executable,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--directory", outputDir,
 		"--log-format", "json",
 	)
 	if err := commands.Run(cmd); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
-	// XXX verify gathered data.
+
+	validate.JSONLog(t, logPath)
 }

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -14,7 +14,7 @@ const executable = "../kubectl-gather"
 func TestGather(t *testing.T) {
 	cmd := exec.Command(
 		executable,
-		"--contexts", strings.Join(clusters.Names(), ","),
+		"--contexts", strings.Join(clusters.Names, ","),
 		"--kubeconfig", clusters.Kubeconfig(),
 		"--directory", "out/test-gather",
 	)
@@ -27,7 +27,7 @@ func TestGather(t *testing.T) {
 func TestJSONLogs(t *testing.T) {
 	cmd := exec.Command(
 		executable,
-		"--contexts", strings.Join(clusters.Names(), ","),
+		"--contexts", strings.Join(clusters.Names, ","),
 		"--kubeconfig", clusters.Kubeconfig(),
 		"--directory", "out/test-json-logs",
 		"--log-format", "json",

--- a/e2e/validate/validate.go
+++ b/e2e/validate/validate.go
@@ -1,0 +1,82 @@
+package validate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Exists(t *testing.T, outputDir string, clusterNames []string, resources []string) {
+	if !pathExists(t, outputDir) {
+		t.Fatalf("output directory %q does not exist", outputDir)
+	}
+
+	for _, cluster := range clusterNames {
+		clusterDir := filepath.Join(outputDir, cluster)
+		if !pathExists(t, clusterDir) {
+			t.Fatalf("cluster directory %q does not exist", clusterDir)
+		}
+		for _, expectedFile := range resources {
+			resource := filepath.Join(clusterDir, expectedFile)
+			matches, err := filepath.Glob(resource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) == 0 {
+				t.Errorf("expected resource %q does not exist", resource)
+			}
+		}
+	}
+}
+
+func Missing(t *testing.T, outputDir string, clusterNames []string, resources []string) {
+	if !pathExists(t, outputDir) {
+		t.Fatalf("output directory %q does not exist", outputDir)
+	}
+
+	for _, cluster := range clusterNames {
+		for _, expectedFile := range resources {
+			resource := filepath.Join(outputDir, cluster, expectedFile)
+			matches, err := filepath.Glob(resource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) > 0 {
+				t.Errorf("expected resource %q should not exist: %q", expectedFile, matches)
+			}
+		}
+	}
+}
+
+func JSONLog(t *testing.T, logPath string) {
+	if !pathExists(t, logPath) {
+		t.Fatalf("log %q does not exist", logPath)
+	}
+
+	file, err := os.Open(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	lineNum := 0
+	for decoder.More() {
+		lineNum++
+		var jsonData map[string]interface{}
+		if err := decoder.Decode(&jsonData); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v", lineNum, err)
+		}
+	}
+}
+
+func pathExists(t *testing.T, path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("error checking path %q: %v", path, err)
+		}
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Changes: 

Validate e2e tests:
Add new validate package validation functions
Validate that expected files and directory structures are created correctly
Add JSON log format validation to ensure --log-format=json works as expected

Additional e2e tests:
Namespace-Specific Test: Add e2e test for gathering data from specific namespaces

Test results:

```
=== RUN   TestGather
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --directory out/test-gather
2025/07/24 13:38:09 2025-07-24T13:38:09.418+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.419+0530	INFO	gather	Gathering from all namespaces
2025/07/24 13:38:09 2025-07-24T13:38:09.419+0530	INFO	gather	Using all addons
2025/07/24 13:38:09 2025-07-24T13:38:09.419+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.419+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.524+0530	INFO	gather	Gathered 306 resources from cluster "kind-c2" in 0.105 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.527+0530	INFO	gather	Gathered 306 resources from cluster "kind-c1" in 0.108 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.527+0530	INFO	gather	Gathered 612 resources from 2 clusters in 0.108 seconds
--- PASS: TestGather (0.14s)
=== RUN   TestGatherEmptyNamespaces
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces=  --directory out/test-gather-empty-namespaces
2025/07/24 13:38:09 2025-07-24T13:38:09.551+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.552+0530	INFO	gather	Gathering from all namespaces
2025/07/24 13:38:09 2025-07-24T13:38:09.552+0530	INFO	gather	Using all addons
2025/07/24 13:38:09 2025-07-24T13:38:09.552+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.552+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.646+0530	INFO	gather	Gathered 306 resources from cluster "kind-c1" in 0.094 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.646+0530	INFO	gather	Gathered 306 resources from cluster "kind-c2" in 0.094 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.646+0530	INFO	gather	Gathered 612 resources from 2 clusters in 0.094 seconds
--- PASS: TestGatherEmptyNamespaces (0.11s)
=== RUN   TestGatherSpecificNamespaces
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1 --directory out/test-gather-specific-namespaces
2025/07/24 13:38:09 2025-07-24T13:38:09.666+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.667+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1"]
2025/07/24 13:38:09 2025-07-24T13:38:09.667+0530	INFO	gather	Using all addons
2025/07/24 13:38:09 2025-07-24T13:38:09.667+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.667+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.691+0530	INFO	gather	Gathered 9 resources from cluster "kind-c2" in 0.024 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.701+0530	INFO	gather	Gathered 17 resources from cluster "kind-c1" in 0.034 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.701+0530	INFO	gather	Gathered 26 resources from 2 clusters in 0.034 seconds
--- PASS: TestGatherSpecificNamespaces (0.05s)
=== RUN   TestGatherAddonsLogs
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons logs --directory out/test-gather-addons-logs
2025/07/24 13:38:09 2025-07-24T13:38:09.719+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.720+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/24 13:38:09 2025-07-24T13:38:09.720+0530	INFO	gather	Using addons ["logs"]
2025/07/24 13:38:09 2025-07-24T13:38:09.720+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.720+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.752+0530	INFO	gather	Gathered 14 resources from cluster "kind-c1" in 0.032 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.755+0530	INFO	gather	Gathered 14 resources from cluster "kind-c2" in 0.035 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.755+0530	INFO	gather	Gathered 28 resources from 2 clusters in 0.035 seconds
--- PASS: TestGatherAddonsLogs (0.05s)
=== RUN   TestGatherAddonsPVCs
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons pvcs --directory out/test-gather-addons-pvcs
2025/07/24 13:38:09 2025-07-24T13:38:09.778+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.779+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/24 13:38:09 2025-07-24T13:38:09.779+0530	INFO	gather	Using addons ["pvcs"]
2025/07/24 13:38:09 2025-07-24T13:38:09.779+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.779+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.812+0530	INFO	gather	Gathered 17 resources from cluster "kind-c2" in 0.033 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.814+0530	INFO	gather	Gathered 17 resources from cluster "kind-c1" in 0.035 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.814+0530	INFO	gather	Gathered 34 resources from 2 clusters in 0.035 seconds
--- PASS: TestGatherAddonsPVCs (0.06s)
=== RUN   TestGatherAddonsEmpty
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons= --directory out/test-gather-addons-empty
2025/07/24 13:38:09 2025-07-24T13:38:09.832+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/24 13:38:09 2025-07-24T13:38:09.833+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/24 13:38:09 2025-07-24T13:38:09.833+0530	INFO	gather	Using addons []
2025/07/24 13:38:09 2025-07-24T13:38:09.833+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/24 13:38:09 2025-07-24T13:38:09.833+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/24 13:38:09 2025-07-24T13:38:09.882+0530	INFO	gather	Gathered 14 resources from cluster "kind-c1" in 0.049 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.883+0530	INFO	gather	Gathered 14 resources from cluster "kind-c2" in 0.050 seconds
2025/07/24 13:38:09 2025-07-24T13:38:09.883+0530	INFO	gather	Gathered 28 resources from 2 clusters in 0.050 seconds
--- PASS: TestGatherAddonsEmpty (0.07s)
=== RUN   TestJSONLogs
2025/07/24 13:38:09 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --directory out/test-json-logs --log-format json
2025/07/24 13:38:09 {"level":"INFO","ts":"2025-07-24T13:38:09.902+0530","logger":"gather","msg":"Using kubeconfig \"out/kubeconfig.yaml\""}
2025/07/24 13:38:09 {"level":"INFO","ts":"2025-07-24T13:38:09.902+0530","logger":"gather","msg":"Gathering from all namespaces"}
2025/07/24 13:38:09 {"level":"INFO","ts":"2025-07-24T13:38:09.902+0530","logger":"gather","msg":"Using all addons"}
2025/07/24 13:38:09 {"level":"INFO","ts":"2025-07-24T13:38:09.902+0530","logger":"gather","msg":"Gathering from cluster \"kind-c1\""}
2025/07/24 13:38:09 {"level":"INFO","ts":"2025-07-24T13:38:09.902+0530","logger":"gather","msg":"Gathering from cluster \"kind-c2\""}
2025/07/24 13:38:10 {"level":"INFO","ts":"2025-07-24T13:38:10.000+0530","logger":"gather","msg":"Gathered 306 resources from cluster \"kind-c2\" in 0.097 seconds"}
2025/07/24 13:38:10 {"level":"INFO","ts":"2025-07-24T13:38:10.004+0530","logger":"gather","msg":"Gathered 306 resources from cluster \"kind-c1\" in 0.102 seconds"}
2025/07/24 13:38:10 {"level":"INFO","ts":"2025-07-24T13:38:10.004+0530","logger":"gather","msg":"Gathered 612 resources from 2 clusters in 0.102 seconds"}
--- PASS: TestJSONLogs (0.13s)
PASS
ok  	github.com/nirs/kubectl-gather/e2e	2.221s
```
[out.tar.gz](https://github.com/user-attachments/files/21403299/out.tar.gz)
