### PR TITLE
go: Update to go 1.24.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        goversion: go.mod
         md5sum: FALSE
         compress_assets: OFF
         build_command: make

--- a/Containerfile
+++ b/Containerfile
@@ -18,9 +18,12 @@ COPY cmd cmd
 COPY pkg pkg
 COPY main.go main.go
 
- # Disable CGO to avoid dependencies on libc. Built image can be built on latest
- # Fedora and run on old RHEL.
-RUN CGO_ENABLED=0 go build -ldflags="${ldflags}"
+# Build env variables:
+# - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. Built image can
+#   be built on latest Fedora and run on old RHEL.
+# - GOTOOLCHAIN=auto: The go command downloads newer toolchain as needed.
+#   https://go.dev/doc/toolchain#download
+RUN GOTOOLCHAIN=auto CGO_ENABLED=0 go build -ldflags="${ldflags}"
 
 FROM docker.io/library/alpine:latest
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: The kubectl-gather authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/golang:1.23 as builder
+ARG go_version
+ARG ldflags
+
+FROM docker.io/library/golang:${go_version} as builder
 
 WORKDIR /build
 
@@ -14,7 +17,6 @@ RUN go mod download
 COPY cmd cmd
 COPY pkg pkg
 COPY main.go main.go
-ARG ldflags
 
  # Disable CGO to avoid dependencies on libc. Built image can be built on latest
  # Fedora and run on old RHEL.

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,10 @@ container:
 container-push: container
 	podman manifest push --all $(image)
 
+# Build env variables:
+# - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. Built image can
+#   be built on latest Fedora and run on old RHEL.
+# - GOTOOLCHAIN=auto: The go command downloads newer toolchain as needed.
+#   https://go.dev/doc/toolchain#download
 kubectl-gather:
-	CGO_ENABLED=0 go build -ldflags="$(ldflags)"
+	GO_TOOLCHAIN=auto CGO_ENABLED=0 go build -ldflags="$(ldflags)"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ version := $(shell git describe --tags | sed -e 's/^v//')
 
 image := $(REGISTRY)/$(REPO)/$(IMAGE):$(version)
 
+go_version := $(shell go list -f "{{.GoVersion}}" -m)
+
 # % go build -ldflags="-help"
 #  -s	disable symbol table
 #  -w	disable DWARF generation
@@ -35,6 +37,7 @@ container:
 		--platform=linux/amd64,linux/arm64 \
 		--manifest $(image) \
 		--build-arg ldflags="$(ldflags)" \
+		--build-arg go_version="$(go_version)" \
 		.
 
 container-push: container

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,9 +2,9 @@ module github.com/nirs/kubectl-gather/e2e
 
 go 1.23
 
-require github.com/spf13/cobra v1.8.1
+require github.com/spf13/cobra v1.9.1
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 )

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,8 @@
 module github.com/nirs/kubectl-gather/e2e
 
-go 1.23
+go 1.24.0
+
+toolchain go1.24.5
 
 require github.com/spf13/cobra v1.9.1
 

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1,10 +1,10 @@
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nirs/kubectl-gather
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
Using same go and toolchain versions as ramen and ramenctl to make it easy to integrate kubectl-gather in ramen related projects.

Changes:
- Go version is specified once in the go.mod.
- The release workflow uses now go version from the go.mod file (like the test workflow).
- The Makefile set GOTOOLCHAIN=auto to download newer toolchain if needed.
- The Containerfile build stage uses go container with version from go.mod
- The Containerfile build command uses GOTOOLCHAIN=auto to download newer toolchain if needed.

Pre-release for testing: https://github.com/nirs/kubectl-gather/releases/tag/v0.9.0-pre2
Pre-release container for testing: quay.io/nirsof/gather:0.9.0-pre2