### PR TITLE
e2e: Improve commands names

### DIFF
--- a/e2e/clusters/clusters.go
+++ b/e2e/clusters/clusters.go
@@ -90,7 +90,7 @@ func createCluster(name string) error {
 		"--kubeconfig", clusterKubeconfig(name),
 		"--wait", "60s",
 	)
-	return commands.LogStderr(cmd)
+	return commands.Run(cmd)
 }
 
 func deleteCluster(name string) error {
@@ -101,7 +101,7 @@ func deleteCluster(name string) error {
 		"--name", kindName(name),
 		"--kubeconfig", config,
 	)
-	if err := commands.LogStderr(cmd); err != nil {
+	if err := commands.Run(cmd); err != nil {
 		return err
 	}
 	_ = os.Remove(config)

--- a/e2e/commands/commands.go
+++ b/e2e/commands/commands.go
@@ -7,7 +7,8 @@ import (
 	"os/exec"
 )
 
-func LogStderr(cmd *exec.Cmd) error {
+// Run a command logging lines from stderr.
+func Run(cmd *exec.Cmd) error {
 	log.Printf("Running %v", cmd)
 	pipe, err := cmd.StderrPipe()
 	if err != nil {

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -18,7 +18,7 @@ func TestGather(t *testing.T) {
 		"--kubeconfig", clusters.Kubeconfig(),
 		"--directory", "out/test-gather",
 	)
-	if err := commands.LogStderr(cmd); err != nil {
+	if err := commands.Run(cmd); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 	// XXX verify gathered data.
@@ -32,7 +32,7 @@ func TestJSONLogs(t *testing.T) {
 		"--directory", "out/test-json-logs",
 		"--log-format", "json",
 	)
-	if err := commands.LogStderr(cmd); err != nil {
+	if err := commands.Run(cmd); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 	// XXX verify gathered data.


### PR DESCRIPTION
Looking at the code after a while, it is not clear how commands are run. Rename commands.LogStderr() to commands.Run() to make it more clear.

Based on #91 for testing.
