### PR TITLE
ci: Run test workflow only for PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
   release:
     types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ name: Test
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Currently we run CI again when pushing to main which is not needed since we require updating PRs before merge.

Add also workflow_dispatch to allow running workflows manually for a branch.