### PR TITLE
 Add validation for cluster node resources

### DIFF
--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -35,6 +35,10 @@ var (
 		"cluster/persistentvolumes/common-pv1.yaml",
 	}
 
+	c1ClusterNodes = []string{
+		"cluster/nodes/c1-control-plane.yaml",
+	}
+
 	c1ClusterResources = []string{
 		"cluster/namespaces/test-c1.yaml",
 	}
@@ -54,6 +58,10 @@ var (
 
 	c1PVCResources = []string{
 		"cluster/persistentvolumes/c1-pv1.yaml",
+	}
+
+	c2ClusterNodes = []string{
+		"cluster/nodes/c2-control-plane.yaml",
 	}
 
 	c2ClusterResources = []string{
@@ -101,21 +109,25 @@ func TestGather(t *testing.T) {
 	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
 	validate.Exists(t, outputDir, clusters.Names, commonLogResources)
 
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterNodes)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1LogResources)
 
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterNodes)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2PVCResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2LogResources)
 
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterNodes)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2PVCResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2NamespaceResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2LogResources)
 
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterNodes)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterResources)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1PVCResources)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1NamespaceResources)
@@ -143,21 +155,25 @@ func TestGatherEmptyNamespaces(t *testing.T) {
 	validate.Exists(t, outputDir, clusters.Names, commonNamespacedResources)
 	validate.Exists(t, outputDir, clusters.Names, commonLogResources)
 
+	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterNodes)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1ClusterResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1PVCResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1NamespaceResources)
 	validate.Exists(t, outputDir, []string{clusters.C1}, c1LogResources)
 
+	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterNodes)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2ClusterResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2PVCResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2NamespaceResources)
 	validate.Exists(t, outputDir, []string{clusters.C2}, c2LogResources)
 
+	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterNodes)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2ClusterResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2PVCResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2NamespaceResources)
 	validate.Missing(t, outputDir, []string{clusters.C1}, c2LogResources)
 
+	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterNodes)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1ClusterResources)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1PVCResources)
 	validate.Missing(t, outputDir, []string{clusters.C2}, c1NamespaceResources)


### PR DESCRIPTION
Changes:

**Cluster node resource:**
- Add `c1ClusterNodes` and `c2ClusterNodes` resource lists to track cluster node files
- Update `TestGather` and `TestGatherEmptyNamespaces` to validate presence and absence of node resources across clusters

```
=== RUN   TestGather
2025/07/25 12:54:41 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --directory out/test-gather
2025/07/25 12:54:42 2025-07-25T12:54:42.689+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:42 2025-07-25T12:54:42.691+0530	INFO	gather	Gathering from all namespaces
2025/07/25 12:54:42 2025-07-25T12:54:42.691+0530	INFO	gather	Using all addons
2025/07/25 12:54:42 2025-07-25T12:54:42.691+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:42 2025-07-25T12:54:42.691+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:42 2025-07-25T12:54:42.842+0530	INFO	gather	Gathered 379 resources from cluster "kind-c1" in 0.151 seconds
2025/07/25 12:54:42 2025-07-25T12:54:42.842+0530	INFO	gather	Gathered 362 resources from cluster "kind-c2" in 0.151 seconds
2025/07/25 12:54:42 2025-07-25T12:54:42.842+0530	INFO	gather	Gathered 741 resources from 2 clusters in 0.151 seconds
--- PASS: TestGather (1.23s)
=== RUN   TestGatherEmptyNamespaces
2025/07/25 12:54:42 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces=  --directory out/test-gather-empty-namespaces
2025/07/25 12:54:42 2025-07-25T12:54:42.862+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:42 2025-07-25T12:54:42.862+0530	INFO	gather	Gathering from all namespaces
2025/07/25 12:54:42 2025-07-25T12:54:42.862+0530	INFO	gather	Using all addons
2025/07/25 12:54:42 2025-07-25T12:54:42.862+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:42 2025-07-25T12:54:42.862+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:43 2025-07-25T12:54:43.019+0530	INFO	gather	Gathered 362 resources from cluster "kind-c2" in 0.157 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.025+0530	INFO	gather	Gathered 379 resources from cluster "kind-c1" in 0.163 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.025+0530	INFO	gather	Gathered 741 resources from 2 clusters in 0.163 seconds
--- PASS: TestGatherEmptyNamespaces (0.18s)
=== RUN   TestGatherSpecificNamespaces
2025/07/25 12:54:43 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1 --directory out/test-gather-specific-namespaces
2025/07/25 12:54:43 2025-07-25T12:54:43.045+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:43 2025-07-25T12:54:43.046+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1"]
2025/07/25 12:54:43 2025-07-25T12:54:43.046+0530	INFO	gather	Using all addons
2025/07/25 12:54:43 2025-07-25T12:54:43.046+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:43 2025-07-25T12:54:43.046+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:43 2025-07-25T12:54:43.072+0530	INFO	gather	Gathered 17 resources from cluster "kind-c2" in 0.026 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.084+0530	INFO	gather	Gathered 33 resources from cluster "kind-c1" in 0.038 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.084+0530	INFO	gather	Gathered 50 resources from 2 clusters in 0.038 seconds
--- PASS: TestGatherSpecificNamespaces (0.06s)
=== RUN   TestGatherAddonsLogs
2025/07/25 12:54:43 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons logs --directory out/test-gather-addons-logs
2025/07/25 12:54:43 2025-07-25T12:54:43.100+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:43 2025-07-25T12:54:43.101+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/25 12:54:43 2025-07-25T12:54:43.101+0530	INFO	gather	Using addons ["logs"]
2025/07/25 12:54:43 2025-07-25T12:54:43.101+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:43 2025-07-25T12:54:43.101+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:43 2025-07-25T12:54:43.140+0530	INFO	gather	Gathered 30 resources from cluster "kind-c2" in 0.039 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.142+0530	INFO	gather	Gathered 30 resources from cluster "kind-c1" in 0.041 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.142+0530	INFO	gather	Gathered 60 resources from 2 clusters in 0.041 seconds
--- PASS: TestGatherAddonsLogs (0.06s)
=== RUN   TestGatherAddonsPVCs
2025/07/25 12:54:43 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons pvcs --directory out/test-gather-addons-pvcs
2025/07/25 12:54:43 2025-07-25T12:54:43.161+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:43 2025-07-25T12:54:43.162+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/25 12:54:43 2025-07-25T12:54:43.162+0530	INFO	gather	Using addons ["pvcs"]
2025/07/25 12:54:43 2025-07-25T12:54:43.162+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:43 2025-07-25T12:54:43.162+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:43 2025-07-25T12:54:43.209+0530	INFO	gather	Gathered 33 resources from cluster "kind-c2" in 0.047 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.213+0530	INFO	gather	Gathered 33 resources from cluster "kind-c1" in 0.051 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.213+0530	INFO	gather	Gathered 66 resources from 2 clusters in 0.051 seconds
--- PASS: TestGatherAddonsPVCs (0.07s)
=== RUN   TestGatherAddonsEmpty
2025/07/25 12:54:43 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces test-common,test-c1,test-c2 --addons= --directory out/test-gather-addons-empty
2025/07/25 12:54:43 2025-07-25T12:54:43.232+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/25 12:54:43 2025-07-25T12:54:43.232+0530	INFO	gather	Gathering from namespaces ["test-common" "test-c1" "test-c2"]
2025/07/25 12:54:43 2025-07-25T12:54:43.232+0530	INFO	gather	Using addons []
2025/07/25 12:54:43 2025-07-25T12:54:43.232+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/25 12:54:43 2025-07-25T12:54:43.232+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/25 12:54:43 2025-07-25T12:54:43.269+0530	INFO	gather	Gathered 30 resources from cluster "kind-c1" in 0.037 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.272+0530	INFO	gather	Gathered 30 resources from cluster "kind-c2" in 0.039 seconds
2025/07/25 12:54:43 2025-07-25T12:54:43.272+0530	INFO	gather	Gathered 60 resources from 2 clusters in 0.039 seconds
--- PASS: TestGatherAddonsEmpty (0.06s)
=== RUN   TestJSONLogs
2025/07/25 12:54:43 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --directory out/test-json-logs --log-format json
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.291+0530","logger":"gather","msg":"Using kubeconfig \"out/kubeconfig.yaml\""}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.291+0530","logger":"gather","msg":"Gathering from all namespaces"}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.291+0530","logger":"gather","msg":"Using all addons"}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.291+0530","logger":"gather","msg":"Gathering from cluster \"kind-c1\""}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.291+0530","logger":"gather","msg":"Gathering from cluster \"kind-c2\""}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.427+0530","logger":"gather","msg":"Gathered 379 resources from cluster \"kind-c1\" in 0.136 seconds"}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.431+0530","logger":"gather","msg":"Gathered 362 resources from cluster \"kind-c2\" in 0.140 seconds"}
2025/07/25 12:54:43 {"level":"INFO","ts":"2025-07-25T12:54:43.431+0530","logger":"gather","msg":"Gathered 741 resources from 2 clusters in 0.140 seconds"}
--- PASS: TestJSONLogs (0.16s)
PASS
ok  	github.com/nirs/kubectl-gather/e2e	2.585s
```