### PR TITLE
Validate empty namespaces flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,10 @@ func runGather(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	if err := validateOptions(); err != nil {
+		log.Fatal(err)
+	}
+
 	if len(namespaces) != 0 {
 		log.Infof("Gathering from namespaces %q", namespaces)
 	} else {
@@ -130,6 +134,14 @@ func runGather(cmd *cobra.Command, args []string) {
 	} else {
 		localGather(clusters)
 	}
+}
+
+func validateOptions() error {
+	// --namespaces=""
+	if namespaces != nil && len(namespaces) == 0 {
+		return fmt.Errorf("nothing to gather: empty --namespaces")
+	}
+	return nil
 }
 
 func createLogger(directory string, verbose bool, format string) *zap.SugaredLogger {

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -152,51 +152,16 @@ func TestGatherEmptyNamespaces(t *testing.T) {
 		"--namespaces=", "",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if err := commands.Run(cmd); err == nil {
+		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
-	// TODO: Empty namespace should result in gathering no resources.
-
-	validate.Exists(t, outputDir, clusters.Names,
-		defaultPVCResources,
-		commonClusterResources,
-		commonPVCResources,
-		commonNamespacedResources,
-		commonLogResources,
-	)
-
-	validate.Exists(t, outputDir, []string{clusters.C1},
-		c1ClusterNodes,
-		c1ClusterResources,
-		c1PVCResources,
-		c1NamespaceResources,
-		c1LogResources,
-	)
-
-	validate.Exists(t, outputDir, []string{clusters.C2},
-		c2ClusterNodes,
-		c2ClusterResources,
-		c2PVCResources,
-		c2NamespaceResources,
-		c2LogResources,
-	)
-
-	validate.Missing(t, outputDir, []string{clusters.C1},
-		c2ClusterNodes,
-		c2ClusterResources,
-		c2PVCResources,
-		c2NamespaceResources,
-		c2LogResources,
-	)
-
-	validate.Missing(t, outputDir, []string{clusters.C2},
-		c1ClusterNodes,
-		c1ClusterResources,
-		c1PVCResources,
-		c1NamespaceResources,
-		c1LogResources,
-	)
+	for _, cluster := range clusters.Names {
+		clusterDir := filepath.Join(outputDir, cluster)
+		if validate.PathExists(t, clusterDir) {
+			t.Errorf("cluster directory %q should not be created", clusterDir)
+		}
+	}
 }
 
 func TestGatherSpecificNamespaces(t *testing.T) {

--- a/e2e/validate/validate.go
+++ b/e2e/validate/validate.go
@@ -9,13 +9,13 @@ import (
 )
 
 func Exists(t *testing.T, outputDir string, clusterNames []string, resources ...[]string) {
-	if !pathExists(t, outputDir) {
+	if !PathExists(t, outputDir) {
 		t.Fatalf("output directory %q does not exist", outputDir)
 	}
 
 	for _, cluster := range clusterNames {
 		clusterDir := filepath.Join(outputDir, cluster)
-		if !pathExists(t, clusterDir) {
+		if !PathExists(t, clusterDir) {
 			t.Fatalf("cluster directory %q does not exist", clusterDir)
 		}
 		for _, pattern := range slices.Concat(resources...) {
@@ -32,7 +32,7 @@ func Exists(t *testing.T, outputDir string, clusterNames []string, resources ...
 }
 
 func Missing(t *testing.T, outputDir string, clusterNames []string, resources ...[]string) {
-	if !pathExists(t, outputDir) {
+	if !PathExists(t, outputDir) {
 		t.Fatalf("output directory %q does not exist", outputDir)
 	}
 
@@ -52,7 +52,7 @@ func Missing(t *testing.T, outputDir string, clusterNames []string, resources ..
 }
 
 func JSONLog(t *testing.T, logPath string) {
-	if !pathExists(t, logPath) {
+	if !PathExists(t, logPath) {
 		t.Fatalf("log %q does not exist", logPath)
 	}
 
@@ -73,7 +73,7 @@ func JSONLog(t *testing.T, logPath string) {
 	}
 }
 
-func pathExists(t *testing.T, path string) bool {
+func PathExists(t *testing.T, path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		if !os.IsNotExist(err) {
 			t.Fatalf("error checking path %q: %v", path, err)


### PR DESCRIPTION
Adds validation to prevent --namespaces="" from gathering no resources. When users specify an empty namespaces, the command now fails with a error message instead of proceeding with unexpected behavior.

Changes:
- Validation Logic: Add validateOptions() function to check for empty namespace flag

e2e:
- Update TestGatherEmptyNamespaces to expect validation error instead of successful execution
- Verify no resources are gathered when validation fails
- Export pathExists function in validate package for direct use in tests

Manual kubectl gather run:

- without --namespaces="" validation, gathers all data:
```
./kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces="" --directory out/test-empty-ns
2025-07-29T18:41:39.901+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025-07-29T18:41:39.902+0530	INFO	gather	Gathering from all namespaces
2025-07-29T18:41:39.902+0530	INFO	gather	Using all addons
2025-07-29T18:41:39.902+0530	INFO	gather	Gathering from cluster "kind-c1"
2025-07-29T18:41:39.902+0530	INFO	gather	Gathering from cluster "kind-c2"
2025-07-29T18:41:40.016+0530	INFO	gather	Gathered 305 resources from cluster "kind-c2" in 0.114 seconds
2025-07-29T18:41:40.016+0530	INFO	gather	Gathered 305 resources from cluster "kind-c1" in 0.114 seconds
2025-07-29T18:41:40.016+0530	INFO	gather	Gathered 610 resources from 2 clusters in 0.114 seconds
```

- with --namespaces="" validation, errors out:
```
./kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces="" --directory out/test-empty-ns
2025-07-29T18:57:53.522+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
cmd: validate empty namespaces flag
2025-07-29T18:57:53.523+0530	FATAL	gather	nothing to gather: empty --namespaces
```

TestGatherEmptyNamespaces without --namespaces="" validation:

```
=== RUN   TestGatherEmptyNamespaces
2025/07/29 14:14:12 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces=  --directory out/test-gather-empty-namespaces
2025/07/29 14:14:12 2025-07-29T14:14:12.046+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/29 14:14:12 2025-07-29T14:14:12.046+0530	INFO	gather	Gathering from all namespaces
2025/07/29 14:14:12 2025-07-29T14:14:12.046+0530	INFO	gather	Using all addons
2025/07/29 14:14:12 2025-07-29T14:14:12.046+0530	INFO	gather	Gathering from cluster "kind-c1"
2025/07/29 14:14:12 2025-07-29T14:14:12.046+0530	INFO	gather	Gathering from cluster "kind-c2"
2025/07/29 14:14:12 2025-07-29T14:14:12.174+0530	INFO	gather	Gathered 363 resources from cluster "kind-c2" in 0.127 seconds
2025/07/29 14:14:12 2025-07-29T14:14:12.177+0530	INFO	gather	Gathered 361 resources from cluster "kind-c1" in 0.131 seconds
2025/07/29 14:14:12 2025-07-29T14:14:12.177+0530	INFO	gather	Gathered 724 resources from 2 clusters in 0.131 seconds
    gather_test.go:156: kubectl-gather should fail, but it succeeded
    gather_test.go:162: cluster directory "out/test-gather-empty-namespaces/kind-c1" should not be created
    gather_test.go:162: cluster directory "out/test-gather-empty-namespaces/kind-c2" should not be created
--- FAIL: TestGatherEmptyNamespaces (0.15s)
```

TestGatherEmptyNamespaces with --namespaces="" validation:
```
=== RUN   TestGatherEmptyNamespaces
2025/07/29 19:52:07 Running ../kubectl-gather --contexts kind-c1,kind-c2 --kubeconfig out/kubeconfig.yaml --namespaces=  --directory out/test-gather-empty-namespaces
2025/07/29 19:52:07 2025-07-29T19:52:07.459+0530	INFO	gather	Using kubeconfig "out/kubeconfig.yaml"
2025/07/29 19:52:07 2025-07-29T19:52:07.460+0530	FATAL	gather	nothing to gather: empty --namespaces
--- PASS: TestGatherEmptyNamespaces (0.02s)
```


