### PR TITLE
add --cluster flag and validate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,88 @@ $ diff -u gather.before/hub/namespaces/deployment-rbd/ramendr.openshift.io/drpla
 ...
 ```
 
+## Gathering cluster scoped resources
+
+When gathering specific namespaces, addons gather related cluster-scoped 
+resources. Use "--cluster=true" to gather all cluster resources instead of 
+just those related to your namespaced resources.
+
+To gather specific namespaces along with cluster scoped resources:
+
+```
+$ kubectl-gather --contexts dr1,dr2 --namespaces=e2e-appset-deploy-cephfs --cluster --directory gather.mixed
+2025-08-01T14:25:15.029+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
+2025-08-01T14:25:15.031+0530	INFO	gather	Gathering from namespaces ["e2e-appset-deploy-cephfs"]
+2025-08-01T14:25:15.031+0530	INFO	gather	Gathering cluster scoped resources
+2025-08-01T14:25:15.031+0530	INFO	gather	Using all addons
+2025-08-01T14:25:15.031+0530	INFO	gather	Gathering from cluster "dr1"
+2025-08-01T14:25:15.031+0530	INFO	gather	Gathering from cluster "dr2"
+2025-08-01T14:25:15.965+0530	INFO	gather	Gathered 458 resources from cluster "dr2" in 0.934 seconds
+2025-08-01T14:25:15.966+0530	INFO	gather	Gathered 475 resources from cluster "dr1" in 0.934 seconds
+2025-08-01T14:25:15.966+0530	INFO	gather	Gathered 933 resources from 2 clusters in 0.934 seconds
+```
+
+This gathers 12M MiB of data into the directory "gather.mixed":
+
+```
+$ du -sh gather.mixed/
+12M	gather.mixed
+```
+
+The gather directory should include namespace and cluster scoped resources:
+
+```
+$ tree -L 3 gather.mixed/
+gather.mixed/
+├── dr1
+│   ├── cluster
+│   │   ├── apiextensions.k8s.io
+│   │   ├── apiregistration.k8s.io
+│   │   ├── certificates.k8s.io
+│   │   ├── cluster.open-cluster-management.io
+│   │   ├── flowcontrol.apiserver.k8s.io
+│   │   ├── namespaces
+│   │   ├── networking.k8s.io
+│   │   ├── nodes
+│   │   ├── operator.open-cluster-management.io
+│   │   ├── operators.coreos.com
+│   │   ├── persistentvolumes
+│   │   ├── ramendr.openshift.io
+│   │   ├── rbac.authorization.k8s.io
+│   │   ├── replication.storage.openshift.io
+│   │   ├── scheduling.k8s.io
+│   │   ├── snapshot.storage.k8s.io
+│   │   ├── storage.k8s.io
+│   │   ├── submariner.io
+│   │   └── work.open-cluster-management.io
+│   └── namespaces
+│       └── e2e-appset-deploy-cephfs
+├── dr2
+│   ├── cluster
+│   │   ├── apiextensions.k8s.io
+│   │   ├── apiregistration.k8s.io
+│   │   ├── certificates.k8s.io
+│   │   ├── cluster.open-cluster-management.io
+│   │   ├── flowcontrol.apiserver.k8s.io
+│   │   ├── namespaces
+│   │   ├── networking.k8s.io
+│   │   ├── nodes
+│   │   ├── operator.open-cluster-management.io
+│   │   ├── operators.coreos.com
+│   │   ├── persistentvolumes
+│   │   ├── ramendr.openshift.io
+│   │   ├── rbac.authorization.k8s.io
+│   │   ├── replication.storage.openshift.io
+│   │   ├── scheduling.k8s.io
+│   │   ├── snapshot.storage.k8s.io
+│   │   ├── storage.k8s.io
+│   │   ├── submariner.io
+│   │   └── work.open-cluster-management.io
+│   └── namespaces
+│       └── e2e-appset-deploy-cephfs
+└── gather.log
+```
+
 ## Gathering remote clusters
 
 When gathering remote clusters it can be faster to gather the data on

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -39,6 +39,7 @@ func localGather(clusterConfigs []*clusterConfig) {
 			Context:    clusterConfig.Context,
 			Namespaces: namespaces,
 			Addons:     addons,
+			Cluster:    cluster,
 			Log:        log.Named(clusterConfig.Context),
 		}
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -16,37 +16,37 @@ type result struct {
 	Err   error
 }
 
-func localGather(clusters []*clusterConfig) {
+func localGather(clusterConfigs []*clusterConfig) {
 	start := time.Now()
 
 	wg := sync.WaitGroup{}
-	results := make(chan result, len(clusters))
+	results := make(chan result, len(clusterConfigs))
 
-	for i := range clusters {
-		cluster := clusters[i]
+	for i := range clusterConfigs {
+		clusterConfig := clusterConfigs[i]
 
-		if cluster.Context != "" {
-			log.Infof("Gathering from cluster %q", cluster.Context)
+		if clusterConfig.Context != "" {
+			log.Infof("Gathering from cluster %q", clusterConfig.Context)
 		} else {
 			log.Info("Gathering on cluster")
 		}
 		start := time.Now()
 
-		directory := filepath.Join(directory, cluster.Context)
+		directory := filepath.Join(directory, clusterConfig.Context)
 
 		options := gather.Options{
 			Kubeconfig: kubeconfig,
-			Context:    cluster.Context,
+			Context:    clusterConfig.Context,
 			Namespaces: namespaces,
 			Addons:     addons,
-			Log:        log.Named(cluster.Context),
+			Log:        log.Named(clusterConfig.Context),
 		}
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			g, err := gather.New(cluster.Config, directory, options)
+			g, err := gather.New(clusterConfig.Config, directory, options)
 			if err != nil {
 				results <- result{Err: err}
 				return
@@ -59,9 +59,9 @@ func localGather(clusters []*clusterConfig) {
 			}
 
 			elapsed := time.Since(start).Seconds()
-			if cluster.Context != "" {
+			if clusterConfig.Context != "" {
 				log.Infof("Gathered %d resources from cluster %q in %.3f seconds",
-					g.Count(), cluster.Context, elapsed)
+					g.Count(), clusterConfig.Context, elapsed)
 			} else {
 				log.Infof("Gathered %d resources on cluster in %.3f seconds",
 					g.Count(), elapsed)
@@ -87,5 +87,5 @@ func localGather(clusters []*clusterConfig) {
 	}
 
 	log.Infof("Gathered %d resources from %d clusters in %.3f seconds",
-		count, len(clusters), time.Since(start).Seconds())
+		count, len(clusterConfigs), time.Since(start).Seconds())
 }

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -97,8 +97,16 @@ func mustGatherCommand(context string, directory string) *exec.Cmd {
 
 	var remoteArgs []string
 
-	if len(namespaces) > 0 {
+	if namespaces != nil {
 		remoteArgs = append(remoteArgs, "--namespaces="+strings.Join(namespaces, ","))
+	}
+
+	// --namespaces not set, --cluster not set -> cluster=true
+	// --namespaces set, --cluster not set -> cluster=false
+	if cluster {
+		remoteArgs = append(remoteArgs, "--cluster=true")
+	} else {
+		remoteArgs = append(remoteArgs, "--cluster=false")
 	}
 
 	if addons != nil {

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -16,20 +16,20 @@ import (
 	"github.com/nirs/kubectl-gather/pkg/gather"
 )
 
-func remoteGather(clusters []*clusterConfig) {
+func remoteGather(clusterConfigs []*clusterConfig) {
 	start := time.Now()
 
 	wg := sync.WaitGroup{}
-	errors := make(chan error, len(clusters))
+	errors := make(chan error, len(clusterConfigs))
 
-	for i := range clusters {
-		cluster := clusters[i]
-		directory := filepath.Join(directory, cluster.Context)
+	for i := range clusterConfigs {
+		clusterConfig := clusterConfigs[i]
+		directory := filepath.Join(directory, clusterConfig.Context)
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := runMustGather(cluster.Context, directory); err != nil {
+			if err := runMustGather(clusterConfig.Context, directory); err != nil {
 				errors <- err
 			}
 		}()
@@ -43,7 +43,7 @@ func remoteGather(clusters []*clusterConfig) {
 	}
 
 	log.Infof("Gathered %d clusters in %.3f seconds",
-		len(clusters), time.Since(start).Seconds())
+		len(clusterConfigs), time.Since(start).Seconds())
 }
 
 func runMustGather(context string, directory string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,7 @@ func runGather(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	clusters, err := loadClusterConfigs(contexts, kubeconfig)
+	clusterConfigs, err := loadClusterConfigs(contexts, kubeconfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -145,9 +145,9 @@ func runGather(cmd *cobra.Command, args []string) {
 	}
 
 	if remote {
-		remoteGather(clusters)
+		remoteGather(clusterConfigs)
 	} else {
-		localGather(clusters)
+		localGather(clusterConfigs)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,10 +124,10 @@ func runGather(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	if len(namespaces) != 0 {
-		log.Infof("Gathering from namespaces %q", namespaces)
-	} else {
+	if namespaces == nil {
 		log.Infof("Gathering from all namespaces")
+	} else if len(namespaces) > 0 {
+		log.Infof("Gathering from namespaces %q", namespaces)
 	}
 
 	if cluster {

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -156,12 +156,25 @@ func TestGatherEmptyNamespaces(t *testing.T) {
 		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
-	for _, cluster := range clusters.Names {
-		clusterDir := filepath.Join(outputDir, cluster)
-		if validate.PathExists(t, clusterDir) {
-			t.Errorf("cluster directory %q should not be created", clusterDir)
-		}
+	validateNoClusterDir(t, outputDir)
+}
+
+func TestGatherEmptyNamespacesClusterFalse(t *testing.T) {
+	outputDir := "out/test-gather-empty-namespaces-cluster-false"
+
+	cmd := exec.Command(
+		kubectlGather,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--kubeconfig", clusters.Kubeconfig(),
+		"--namespaces=", "",
+		"--cluster=false",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd); err == nil {
+		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
+
+	validateNoClusterDir(t, outputDir)
 }
 
 func TestGatherSpecificNamespaces(t *testing.T) {
@@ -346,4 +359,15 @@ func TestJSONLogs(t *testing.T) {
 	}
 
 	validate.JSONLog(t, logPath)
+}
+
+// Test helpers
+
+func validateNoClusterDir(t *testing.T, outputDir string) {
+	for _, cluster := range clusters.Names {
+		clusterDir := filepath.Join(outputDir, cluster)
+		if validate.PathExists(t, clusterDir) {
+			t.Errorf("cluster directory %q should not be created", clusterDir)
+		}
+	}
 }

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -43,6 +43,7 @@ type Options struct {
 	Context    string
 	Namespaces []string
 	Addons     []string
+	Cluster    bool
 	Log        *zap.SugaredLogger
 }
 
@@ -186,11 +187,11 @@ func (g *Gatherer) prepare() error {
 			// Nothing to gather - expected conditions when gathering namespace
 			// from multiple cluster when namespace exists only on some.
 			g.log.Debug("No namespace to gather")
-			return nil
+			if !g.opts.Cluster {
+				return nil
+			}
 		}
-	}
-
-	if len(namespaces) == 0 {
+	} else if g.opts.Namespaces == nil {
 		namespaces = []string{metav1.NamespaceAll}
 	}
 
@@ -210,7 +211,7 @@ func (g *Gatherer) prepare() error {
 					return nil
 				})
 			}
-		} else if g.opts.Namespaces == nil {
+		} else if g.opts.Cluster {
 			g.gatherQueue.Queue(func() error {
 				g.gatherResources(r, "")
 				return nil

--- a/pkg/gather/pvcs.go
+++ b/pkg/gather/pvcs.go
@@ -35,8 +35,8 @@ func NewPVCAddon(backend AddonBackend) (Addon, error) {
 }
 
 func (a *pvcsAddon) Inspect(pvc *unstructured.Unstructured) error {
-	// Needed only when gathering specific namespaces.
-	if len(a.Options().Namespaces) == 0 {
+	// When cluster flag is set, PV and StorageClass resources are already gathered at cluster level
+	if a.Options().Cluster {
 		return nil
 	}
 


### PR DESCRIPTION
- Add `clusterScope` flag to control gathering cluster-scoped resources.
- Add examples in help text for using the `--cluster` flag.
- Implement `validateOptions()` to enforce that empty namespaces can only
  be used when cluster scope is enabled and gather all resources if neither
  namespaces nor cluster flags are set.
- Document gathering cluster scope resources
-  add test for empty namespaces with --cluster=false
- add tests for --cluster flag combinations
    - TestGatherClusterTrue: --cluster=true
    - TestGatherClusterFalse: --cluster=false
    - TestGatherEmptyNamespacesClusterTrue: --namespaces="" --cluster=true
    - TestGatherSpecificNamespacesClusterTrue: specific namespaces + cluster
    - TestGatherSpecificNamespacesClusterFalse: specific namespaces only

Fixes #98 
