### PR TITLE
e2e: fix lint errors in output_test.go

### DIFF
--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -39,10 +39,10 @@ func TestOutput(t *testing.T) {
 		if err := yaml.Unmarshal(data, &deployment); err != nil {
 			t.Fatal(err)
 		}
-		if deployment.ObjectMeta.Name != name {
-			t.Errorf("expected deployment name %q, got %s", name, deployment.ObjectMeta.Name)
+		if deployment.Name != name {
+			t.Errorf("expected deployment name %q, got %s", name, deployment.Name)
 		}
-		t.Logf("Read deployment %q", deployment.ObjectMeta.Name)
+		t.Logf("Read deployment %q", deployment.Name)
 	})
 
 	t.Run("pods", func(t *testing.T) {
@@ -64,10 +64,10 @@ func TestOutput(t *testing.T) {
 			if err := yaml.Unmarshal(data, &pod); err != nil {
 				t.Fatal(err)
 			}
-			if pod.ObjectMeta.Name != name {
-				t.Errorf("expected pod name %q, got %s", name, pod.ObjectMeta.Name)
+			if pod.Name != name {
+				t.Errorf("expected pod name %q, got %s", name, pod.Name)
 			}
-			t.Logf("Read pod %q", pod.ObjectMeta.Name)
+			t.Logf("Read pod %q", pod.Name)
 		}
 	})
 
@@ -90,10 +90,10 @@ func TestOutput(t *testing.T) {
 			if err := yaml.Unmarshal(data, &namespace); err != nil {
 				t.Fatal(err)
 			}
-			if namespace.ObjectMeta.Name != name {
-				t.Errorf("expected namespace name %q, got %s", name, namespace.ObjectMeta.Name)
+			if namespace.Name != name {
+				t.Errorf("expected namespace name %q, got %s", name, namespace.Name)
 			}
-			t.Logf("Read namespace %q", namespace.ObjectMeta.Name)
+			t.Logf("Read namespace %q", namespace.Name)
 		}
 	})
 }


### PR DESCRIPTION
Fix for manually found lint errors:
```
make lint
golangci-lint run ./...
0 issues.
cd e2e && golangci-lint run ./...
e2e/output_test.go:42:17: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
e2e: fix lint errors in output_test.go
		if deployment.ObjectMeta.Name != name {
		              ^
e2e/output_test.go:43:69: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			t.Errorf("expected deployment name %q, got %s", name, deployment.ObjectMeta.Name)
			                                                                 ^
e2e/output_test.go:45:43: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		t.Logf("Read deployment %q", deployment.ObjectMeta.Name)
		                                        ^
3 issues:
* staticcheck: 3
```

Use direct Name field access instead of ObjectMeta.Name for resources to comply with linting rules.

```
make lint
golangci-lint run ./...
0 issues.
cd e2e && golangci-lint run ./...
0 issues.
```