### PR TITLE
release: Fetch tags when building the container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         build_command: make
   release-container:
     name: Release container
-    runs-on: ubuntu-24.04  # for recent enough podman
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
 
   container:
     name: Build container
-    runs-on: ubuntu-24.04  # for recent enough podman
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
The current release container job does not fetch the tags:

    /usr/bin/git -c protocol.version=2 fetch --no-tags --prune ...

and then it fails to get the version and build with empty version:

    fatal: No names found, cannot describe anything.
    podman build \
            --platform=linux/amd64,linux/arm64 \
            --manifest quay.io/nirsof/gather: \
            --build-arg ldflags="-s -w -X 'github.com/nirs/kubectl-gather/pkg/gather.Version=' -X 'github.com/nirs/kubectl-gather/pkg/gather.Image=quay.io/nirsof/gather:'" \
            --build-arg go_version="1.24.0" \

This causes the github build to fail with:

    Error: invalid reference format

And when using using image built locally, running oc fails:

    2025-08-03T17:09:10.521+0300	FATAL	gather	oc adm must-gather error: exit status 1:

    Error running must-gather collection:
        unable to parse image reference quay.io/nirsof/gather:: invalid reference format

This is expected since we create an image with empty tag which is invalid.

The same checkout works in the release-binaries job running on
ubuntu-latest. Lets try to use the same runner in all workflows.