### PR TITLE
build: Allow building with existing image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 # SPDX-FileCopyrightText: The kubectl-gather authors
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY ?= quay.io
-REPO ?= nirsof
-IMAGE ?= gather
-
-package := github.com/nirs/kubectl-gather/pkg/gather
-
 # 0.5.1 when building from tag (release)
 # 0.5.1-1-gcf79160 when building without tag (development)
 version := $(shell git describe --tags | sed -e 's/^v//')
 
-image := $(REGISTRY)/$(REPO)/$(IMAGE):$(version)
+REGISTRY ?= quay.io
+REPO ?= nirsof
+IMAGE ?= gather
+TAG ?= $(version)
+
+package := github.com/nirs/kubectl-gather/pkg/gather
+
+image := $(REGISTRY)/$(REPO)/$(IMAGE):$(TAG)
 
 go_version := $(shell go list -f "{{.GoVersion}}" -m)
 


### PR DESCRIPTION
Add optional TAG argument to allow building a version using existing image.

Example usage:

    % make TAG=test
    GO_TOOLCHAIN=auto CGO_ENABLED=0 go build -ldflags="-s -w -X 'github.com/nirs/kubectl-gather/pkg/gather.Version=0.9.0-7-g88fef25' -X 'github.com/nirs/kubectl-gather/pkg/gather.Image=quay.io/nirsof/gather:test'"

If not set we build with the version (current behavior):

    % make
    GO_TOOLCHAIN=auto CGO_ENABLED=0 go build -ldflags="-s -w -X 'github.com/nirs/kubectl-gather/pkg/gather.Version=0.9.0-7-gce7b1f9' -X 'github.com/nirs/kubectl-gather/pkg/gather.Image=quay.io/nirsof/gather:0.9.0-7-gce7b1f9'"