### PR TITLE
build: Use go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nirs/kubectl-gather
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.25.0
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
We keep go 1.24.0 to be compatible with downstream consumes of this package. For building ramenctl we should always use latest go version.

With this change we use go 1.25.0 to build for tests, building the executables, and running golangci-lint.