### PR TITLE
Handle non existent dirs in ListResources

### DIFF
--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -96,4 +96,24 @@ func TestOutput(t *testing.T) {
 			t.Logf("Read namespace %q", namespace.Name)
 		}
 	})
+
+	t.Run("list non existent directory", func(t *testing.T) {
+		namespaceResources, err := reader.ListResources("test-common", "non-existent")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(namespaceResources) != 0 {
+			t.Errorf("expected empty slice, got %d resources: %v",
+				len(namespaceResources), namespaceResources)
+		}
+
+		clusterResources, err := reader.ListResources("", "non-existent")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(clusterResources) != 0 {
+			t.Errorf("expected empty slice, got %d resources: %v",
+				len(clusterResources), clusterResources)
+		}
+	})
 }

--- a/pkg/gather/output_reader.go
+++ b/pkg/gather/output_reader.go
@@ -29,6 +29,9 @@ func (r *OutputReader) ListResources(namespace, resource string) ([]string, erro
 
 	entries, err := os.ReadDir(resourceDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Return empty slice instead of error when resource directory doesn't exist. This allows callers to handle missing resources without explicit error checking. Also added e2e test covering this case.


e2e:

```
=== RUN   TestOutput/deployment
    output_test.go:45: Read deployment "common-busybox"
=== RUN   TestOutput/pods
    output_test.go:56: Listed pods ["common-busybox-85888ff8f9-lchrr"]
    output_test.go:70: Read pod "common-busybox-85888ff8f9-lchrr"
=== RUN   TestOutput/cluster_scope
    output_test.go:82: Listed namespaces ["default" "kube-node-lease" "kube-public" "kube-system" "local-path-storage" "test-c1" "test-common"]
    output_test.go:96: Read namespace "default"
    output_test.go:96: Read namespace "kube-node-lease"
    output_test.go:96: Read namespace "kube-public"
    output_test.go:96: Read namespace "kube-system"
    output_test.go:96: Read namespace "local-path-storage"
    output_test.go:96: Read namespace "test-c1"
    output_test.go:96: Read namespace "test-common"
=== RUN   TestOutput/list_non_existent_directory
--- PASS: TestOutput (0.12s)
    --- PASS: TestOutput/deployment (0.00s)
    --- PASS: TestOutput/pods (0.00s)
    --- PASS: TestOutput/cluster_scope (0.00s)
    --- PASS: TestOutput/list_non_existent_directory (0.00s)
```