### PR TITLE
ci: Build container images natively in parallel

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: The kubectl-gather authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Container
+
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+
+  container-native:
+    name: Build ${{ matrix.goarch }} image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            runner: ubuntu-24.04
+          - goarch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Create build tag
+        run: git describe --tags 2>/dev/null || git tag latest
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Build and save image
+        run: make gather-${{ matrix.goarch }}.tar
+      - name: Upload image
+        uses: actions/upload-artifact@v6
+        with:
+          name: gather-${{ matrix.goarch }}
+          path: gather-${{ matrix.goarch }}.tar
+          compression-level: 0
+          retention-days: 1
+
+  container-multiarch:
+    name: Build multiarch image
+    runs-on: ubuntu-latest
+    needs: container-native
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Create build tag
+        run: git describe --tags 2>/dev/null || git tag latest
+      - name: Download images
+        uses: actions/download-artifact@v7
+        with:
+          pattern: gather-*
+          merge-multiple: true
+      - name: Create multiarch image
+        run: |
+          podman load -i gather-amd64.tar
+          podman load -i gather-arm64.tar
+          make container-multiarch
+      - name: Save multiarch image
+        run: make gather.tar
+      - name: Upload multiarch image
+        uses: actions/upload-artifact@v6
+        with:
+          name: gather
+          path: gather.tar
+          compression-level: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,22 +37,27 @@ jobs:
         md5sum: FALSE
         compress_assets: OFF
         build_command: make
+
+  container:
+    name: Container
+    uses: ./.github/workflows/container.yaml
+
   release-container:
     name: Release container
     runs-on: ubuntu-latest
+    needs: container
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
-      - name: Setup multi-arch podman
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-user-static podman
-          podman version
+      - name: Download multiarch image
+        uses: actions/download-artifact@v7
+        with:
+          name: gather
       - name: Login to quay.io
         uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Build and push container
-        run: make container-push
+      - name: Push container
+        run: make container-multiarch-push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,19 +51,3 @@ jobs:
           cache: false
       - name: Build binary
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make
-
-  container:
-    name: Build container
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
-      - name: Create build tag
-        run: git tag latest
-      - name: Setup multi-arch podman
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-user-static podman
-          podman version
-      - name: Make container
-        run: make container

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ REGISTRY ?= quay.io
 REPO ?= nirsof
 IMAGE ?= gather
 TAG ?= $(version)
+GOARCH ?= $(shell go env GOARCH)
 
 package := github.com/nirs/kubectl-gather/pkg/gather
 
 image := $(REGISTRY)/$(REPO)/$(IMAGE):$(TAG)
+image_arch = $(image)-$(GOARCH)
 
-go_version := $(shell go list -f "{{.GoVersion}}" -m)
+# Lazy evaluation - resolved only when used by targets that need it.
+go_version = $(shell go list -f "{{.GoVersion}}" -m)
 
 # % go build -ldflags="-help"
 #  -s	disable symbol table
@@ -25,7 +28,8 @@ ldflags := -s -w \
 	-X '$(package).Version=$(version)' \
 	-X '$(package).Image=$(image)'
 
-.PHONY: all kubectl-gather
+.PHONY: all kubectl-gather lint container container-native \
+	container-multiarch container-push container-multiarch-push
 
 all: kubectl-gather
 
@@ -33,6 +37,7 @@ lint:
 	golangci-lint run ./...
 	cd e2e && golangci-lint run ./...
 
+# Build multiarch image locally using qemu emulation.
 container:
 	podman build \
 		--platform=linux/amd64,linux/arm64 \
@@ -41,8 +46,38 @@ container:
 		--build-arg go_version="$(go_version)" \
 		.
 
-container-push: container
+container-push:
 	podman manifest push --all $(image)
+
+# Parallel native container build targets used by github workflow.
+
+# Build image for the native architecture.
+container-native:
+	podman build \
+		--tag $(image_arch) \
+		--build-arg ldflags="$(ldflags)" \
+		--build-arg go_version="$(go_version)" \
+		.
+
+# Save native image as OCI archive.
+$(IMAGE)-$(GOARCH).tar: container-native
+	podman save --format oci-archive -o $@ $(image_arch)
+
+# Create multiarch manifest from per-arch images.
+# Use containers-storage: to reference local images, otherwise podman
+# tries to pull from the registry.
+container-multiarch:
+	podman manifest create $(image) \
+		containers-storage:$(image)-amd64 \
+		containers-storage:$(image)-arm64
+
+# Save multiarch manifest as OCI archive.
+$(IMAGE).tar:
+	podman manifest push --all $(image) oci-archive:$@
+
+# Push multiarch OCI archive to registry.
+container-multiarch-push:
+	skopeo copy --all oci-archive:$(IMAGE).tar docker://$(image)
 
 # Build env variables:
 # - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. Built image can


### PR DESCRIPTION
Replace qemu cross-compilation with parallel native builds using GitHub's ARM64 runners.

The container build is defined once in container.yaml and tested on every PR. Only the push to quay.io is release-specific.

PR flow (container.yaml):
- Build amd64 image on ubuntu-24.04 runner
- Build arm64 image on ubuntu-24.04-arm runner
- Both run in parallel, saving OCI archives as artifacts
- Download both archives and assemble a multiarch manifest
- Upload multiarch OCI archive for testing with podman or docker

Release flow (release.yaml):
- Call the container workflow to build the multiarch image
- Download the multiarch OCI archive
- Push to quay.io using skopeo

## Compare to old build

| | Old (qemu) | New (native) |
|---|---|---|
| AMD64 build | 60s | 45s |
| ARM64 build | 12m 17s (qemu) | 45s (native) |
| Multiarch assembly | 0s (same job) | 14s (separate job) |
| **Total wall time** | **14m 35s** | **1m 30s** |
| qemu required | yes | no |
| Runners | 1x ubuntu-latest | 2x (amd64 + arm64) |