### PR TITLE
ci: Switch container registry from quay.io to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
 
   release-container:
     name: Release container
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     needs: container
     steps:
@@ -53,11 +55,11 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: gather
-      - name: Login to quay.io
+      - name: Login to ghcr.io
         uses: docker/login-action@v4
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_ROBOT }}
-          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push container
-        run: make container-multiarch-push
+        run: make container-multiarch-push REPO=${{ github.repository_owner }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,29 +112,29 @@ make container PLATFORMS=linux/arm64
 
 ## Push a container image to your registry
 
-The release workflow pushes the container image automatically. You
-should not need to push manually. If you do, push to your own registry:
+The release workflow pushes the container image to ghcr.io automatically.
+You should not need to push manually. If you do, create a GitHub Personal
+Access Token (classic) with `write:packages` scope. Fine-grained tokens
+do not support GitHub Packages yet.
 
-1. Build the container for your repo:
+Create a token at https://github.com/settings/tokens/new?scopes=write:packages
 
-   ```console
-   make container REPO=my-quay-user
-   ```
-
-2. Login to the registry:
+1. Login to ghcr.io using the PAT as the password:
 
    ```console
-   podman login quay.io -u my-quay-user
+   podman login ghcr.io -u my-github-user
    ```
 
-3. Push to your repo:
+2. Push to your ghcr.io repo:
 
    ```console
-   make container-push REPO=my-quay-user
+   make container-push REPO=my-github-user
    ```
 
-> [!IMPORTANT]
-> Make your repo public so `kubectl-gather --remote` can pull the image.
+3. If this is your first push, make the package public so
+   `kubectl-gather --remote` can pull it. GHCR packages are private
+   by default. Change the visibility at
+   `https://github.com/users/<username>/packages/container/gather/settings`.
 
 ## Sending pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 # 0.5.1-1-gcf79160 when building without tag (development)
 version := $(shell git describe --tags | sed -e 's/^v//')
 
-REGISTRY ?= quay.io
-REPO ?= nirsof
+REGISTRY ?= ghcr.io
+REPO ?= nirs
 IMAGE ?= gather
 TAG ?= $(version)
 GOARCH ?= $(shell go env GOARCH)

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -37,7 +37,7 @@ const workQueueSize = 6
 // Replaced during build with actual values.
 var Version = "devel"
 var Commit = "unknown"
-var Image = "quay.io/nirsof/gather:devel"
+var Image = "ghcr.io/nirs/gather:devel"
 
 // VersionInfo describes the gather build.
 type VersionInfo struct {


### PR DESCRIPTION
Use GitHub Container Registry instead of quay.io for publishing
container images. The image is pulled by kubectl-gather using the
image name baked into the binary, so this change is transparent
to users.

Benefits:
- Auth via GITHUB_TOKEN, no need to manage external secrets
- Contributors can test release workflow in forks, pushing to
  ghcr.io/<fork-owner>/gather
- Much better user interface for inspecting the container image
- Container image integrated in the project page

Limitations:
- Manual push requires a classic PAT with write:packages scope
  (fine-grained tokens do not support GitHub Packages yet)
- GHCR packages are private by default and must be made public
  after the first push

Example package: https://github.com/nirs/kubectl-gather/pkgs/container/gather

## Integration in project page

<img width="317" height="275" alt="Integration in project page" src="https://github.com/user-attachments/assets/7a8aa7d2-e18e-49be-802e-9c2b644aa5c2" />

## Testing with minikube cluster

```
% minikube start --driver vfkit --network vmnet-shared
😄  minikube v1.38.1 on Darwin 26.4 (arm64)
✨  Using the vfkit driver based on user configuration
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
📦  Preparing Kubernetes v1.35.1 on containerd 2.2.1 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

% kubectl gather -d out/minikube.gather --remote
2026-03-29T02:55:02.325+0300	INFO	gather	Using kubeconfig "/Users/nir/.kube/config"
2026-03-29T02:55:02.325+0300	INFO	gather	Using current context "minikube"
2026-03-29T02:55:02.325+0300	INFO	gather	Using generated salt "aVNwq5PXHjX4SgY/MbZnwA=="
2026-03-29T02:55:02.325+0300	INFO	gather	Gathering from all namespaces
2026-03-29T02:55:02.325+0300	INFO	gather	Gathering cluster scoped resources
2026-03-29T02:55:02.325+0300	INFO	gather	Using all addons
2026-03-29T02:55:02.325+0300	INFO	gather	Gathering on remote cluster "minikube"
2026-03-29T02:55:12.645+0300	INFO	gather	Gathered on remote cluster "minikube" in 10.320 seconds
2026-03-29T02:55:12.646+0300	INFO	gather	Gathered 1 clusters in 10.320 seconds

% tree -L 2 out/minikube.gather 
out/minikube.gather
├── gather.log
└── minikube
    ├── event-filter.html
    ├── ghcr-io-nirs-gather-sha256-ee2da909e058e00382b14e9580898fe519c0f211a8fd3254e3bf9a8ea42f1c05
    ├── must-gather.log
    ├── must-gather.logs
    └── timestamp

3 directories, 5 files
```

## Image pull performance: quay.io vs ghcr.io

Tested cold image pulls on fresh minikube clusters (macOS arm64, vfkit
driver, vmnet-shared networking). Each run creates fresh clusters, deploys
test workloads, then runs `kubectl gather --remote` pulling a 37MB image.

### quay.io (AWS CloudFront CDN)

| Run | c1 pull time | c2 pull time |
|-----|-------------|-------------|
| 1   | 10.1s       | 10.0s       |
| 2   | 3.4s        | 3.7s        |
| 3   | 3.5s        | 3.8s        |

### ghcr.io (pkg-containers.githubusercontent.com)

| Run | c1 pull time | c2 pull time |
|-----|-------------|-------------|
| 1   | 53.2s       | 79.7s       |
| 2   | 34.9s       | 56.4s       |
| 3   | 25.3s       | 63.3s       |

### Summary

| Registry | Median | Min   | Max   | CDN                |
|----------|--------|-------|-------|--------------------|
| quay.io  | 3.7s   | 3.4s  | 10.1s | AWS CloudFront     |
| ghcr.io  | 54.8s  | 25.3s | 79.7s | GitHub (known IPv6 routing issues) |

quay.io is 5-15x faster and much more consistent. ghcr.io has a [known
issue](https://github.com/containerd/containerd/issues/9846) with slow
pulls caused by IPv6 routing to `pkg-containers.githubusercontent.com`.

### CDN cache warmup test

The slow ghcr.io pulls above are caused by cold CDN edge cache. After
warming up the cache with repeated pulls, both registries perform equally.

Test scripts run inside minikube VM using `crictl` (containerd). Each
iteration removes the image (`crictl rmi` purges all layers) and pulls
again:

```bash
# test-ghcr.sh
sudo crictl rmi ghcr.io/nirs/gather:0.13.0-pre8 2>/dev/null
for i in $(seq 10); do
    echo "ghcr.io ($i/10)"
    time sudo crictl pull ghcr.io/nirs/gather:0.13.0-pre8
    sudo crictl rmi ghcr.io/nirs/gather:0.13.0-pre8 2>/dev/null
done
```

```bash
# test-quay.sh
sudo crictl rmi quay.io/nirsof/gather:0.13.0-pre9 2>/dev/null
for i in $(seq 10); do
    echo "quay.io ($i/10)"
    time sudo crictl pull quay.io/nirsof/gather:0.13.0-pre9
    sudo crictl rmi quay.io/nirsof/gather:0.13.0-pre9 2>/dev/null
done
```

#### Results with warm CDN cache (10 pulls each)

| Registry | Min  | Max  | Mean |
|----------|------|------|------|
| ghcr.io  | 2.8s | 3.3s | 2.9s |
| quay.io  | 2.4s | 3.1s | 2.7s |

Verified that `crictl rmi` actually purges layers (content store drops
from 36MB to 124KB after rmi), so these are real downloads, not cache
hits.

Note: The slow ghcr.io pulls (runs 1-3) were all within minutes of pushing
the image. Testing an hour later show similar performance to quay.io. This
may be slower cache edge for ghcr.io.