### PR TITLE
container: Use toolchain version for base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,9 +21,7 @@ COPY main.go main.go
 # Build env variables:
 # - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. Built image can
 #   be built on latest Fedora and run on old RHEL.
-# - GOTOOLCHAIN=auto: The go command downloads newer toolchain as needed.
-#   https://go.dev/doc/toolchain#download
-RUN GOTOOLCHAIN=auto CGO_ENABLED=0 go build -ldflags="${ldflags}"
+RUN CGO_ENABLED=0 go build -ldflags="${ldflags}"
 
 FROM docker.io/library/alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ package := github.com/nirs/kubectl-gather/pkg/gather
 image := $(REGISTRY)/$(REPO)/$(IMAGE):$(TAG)
 image_arch = $(image)-$(GOARCH)
 
-# Lazy evaluation - resolved only when used by targets that need it.
-go_version = $(shell go list -f "{{.GoVersion}}" -m)
+# Use the toolchain version for the container base image so go build inside
+# the container does not need to download a newer toolchain.
+go_version = $(shell go mod edit -json | jq -r .Toolchain | sed 's/^go//')
 
 # % go build -ldflags="-help"
 #  -s	disable symbol table


### PR DESCRIPTION
Use the Go toolchain version from go.mod instead of the go directive version for the container base image. This avoids downloading a newer toolchain inside the container on every build, since GOTOOLCHAIN=auto would upgrade from the go directive version (1.25.0) to the toolchain version (1.26.1).