### PR TITLE
Improve container build performance and labeling

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,5 +40,7 @@ COPY --from=builder /build/kubectl-gather /usr/bin/kubectl-gather
 COPY gather /usr/bin/gather
 COPY LICENSE licenses/Apache-2.0.txt
 
+LABEL org.opencontainers.image.source=https://github.com/nirs/kubectl-gather
+
 # Use exec form to allow passing arguemnts from docker commmand.
 ENTRYPOINT ["/usr/bin/gather"]


### PR DESCRIPTION
- Use Go compile object cache (`--mount=type=cache`) to persist
  compiled objects across local builds, reducing rebuild time from
  ~40s to ~5s on code changes
- Add OCI source label to link the image to the GitHub repository
