### PR TITLE
container: Switch from Alpine to UBI for image scanning support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -53,6 +53,7 @@ RUN mkdir -p /install-root/etc && \
 # - bash: required by the gather script
 # - tar, gzip: required by kubectl-gather for streaming files from pods
 # - rsync: required by oc adm must-gather to copy data from the pod
+# - gawk: provides awk, required by must-gather volume percentage checker
 # - util-linux-core: provides setsid -w, required by must-gather
 #
 # Removals:
@@ -67,7 +68,7 @@ RUN microdnf install -y \
         --setopt=install_weak_deps=0 \
         --releasever=9 \
         --nodocs \
-        bash tar gzip rsync util-linux-core \
+        bash tar gzip gawk rsync util-linux-core \
     && microdnf clean all \
     && rm -rf /install-root/usr/lib64/gconv
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,16 +1,26 @@
 # SPDX-FileCopyrightText: The kubectl-gather authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Build using 3 stages to create a minimal image with Red Hat UBI
+# components, enabling security scanning on quay.io:
+#
+# 1. golang       - build the kubectl-gather binary
+# 2. ubi-minimal  - install RPM packages into a separate --installroot
+#                   and download kubectl (ubi-micro has no package manager)
+# 3. ubi-micro    - copy the install root and binaries into the final image
+
+# Stage 1: Build kubectl-gather
+
 ARG go_version
 
-FROM docker.io/library/golang:${go_version} as builder
+FROM docker.io/library/golang:${go_version} AS builder
 
 WORKDIR /build
 
 COPY go.mod go.sum ./
 
 # Cache dependencies before copying sources so source changes do not
-# invalidated cacehd dependencies.
+# invalidate cached dependencies.
 RUN go mod download
 
 COPY cmd cmd
@@ -20,29 +30,63 @@ COPY main.go main.go
 ARG ldflags
 
 # Build env variables:
-# - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. Built image can
-#   be built on latest Fedora and run on old RHEL.
+# - CGO_ENABLED=0: Disable CGO to avoid dependencies on libc. The binary can be
+#   built on latest Fedora and run on old RHEL.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 go build -ldflags="${ldflags}"
 
-FROM docker.io/library/alpine:latest
+# Stage 2: Install dependencies into /install-root
 
-# Required for must-gather: rsync, bash, setsid (util-linux)
-# Required for kubectl-gather: tar, kubectl
-RUN apk add --no-cache \
-        bash \
-        rsync \
-        tar \
-        util-linux \
-    && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-        kubectl \
-    && mkdir -p licenses
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS base
 
+# microdnf requires os-release in the install root.
+RUN mkdir -p /install-root/etc && \
+    cp /etc/os-release /install-root/etc/os-release
+
+# Install packages into /install-root for copying into the final
+# ubi-micro image. microdnf requires --noplugins, --config, and --setopt
+# for cachedir/reposdir/varsdir when using --installroot.
+# --setopt=install_weak_deps=0 avoids optional dependencies to minimize
+# the install size.
+#
+# Packages:
+# - bash: required by the gather script
+# - tar, gzip: required by kubectl-gather for streaming files from pods
+# - rsync: required by oc adm must-gather to copy data from the pod
+# - util-linux-core: provides setsid -w, required by must-gather
+#
+# Removals:
+# - Remove glibc locale conversion modules (~20 MB), not needed.
+RUN microdnf install -y \
+        --installroot=/install-root \
+        --noplugins \
+        --config=/etc/dnf/dnf.conf \
+        --setopt=cachedir=/var/cache/dnf \
+        --setopt=reposdir=/etc/yum.repos.d \
+        --setopt=varsdir=/etc/dnf/vars \
+        --setopt=install_weak_deps=0 \
+        --releasever=9 \
+        --nodocs \
+        bash tar gzip rsync util-linux-core \
+    && microdnf clean all \
+    && rm -rf /install-root/usr/lib64/gconv
+
+# Download upstream kubectl (smaller than OpenShift's oc/kubectl bundle).
+ARG TARGETARCH
+RUN KUBE_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt) && \
+    curl -fSLo /install-root/usr/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
+    chmod +x /install-root/usr/bin/kubectl
+
+# Stage 3: Final image
+
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+
+COPY --from=base /install-root /
 COPY --from=builder /build/kubectl-gather /usr/bin/kubectl-gather
 COPY gather /usr/bin/gather
 COPY LICENSE licenses/Apache-2.0.txt
 
 LABEL org.opencontainers.image.source=https://github.com/nirs/kubectl-gather
 
-# Use exec form to allow passing arguemnts from docker commmand.
 ENTRYPOINT ["/usr/bin/gather"]

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,7 @@ container:
 		.
 
 container-push:
-	podman save --format oci-archive -o $(IMAGE).tar $(image)
-	skopeo copy --all oci-archive:$(IMAGE).tar docker://$(image)
-	rm -f $(IMAGE).tar
+	podman manifest push --all $(image)
 
 # Parallel native container build targets used by github workflow.
 


### PR DESCRIPTION
Use Red Hat UBI images to enable security scanning on quay.io, required for OpenShift users.

Using ubi-micro as the final image keeps the image small (174 MB uncompressed) but requires a more complex build since ubi-micro has no package manager. We use ubi-minimal as an intermediate stage to install RPM packages into a separate --installroot directory, then copy the result into the final ubi-micro image.

Build stages:
1. golang      - build the kubectl-gather binary
2. ubi-minimal - install RPM packages into --installroot and download
                 kubectl
3. ubi-micro   - copy the prepared root and binaries into the final image

Using ubi-minimal directly as the final image would simplify the build but adds ~87 MB (111 MB vs 24 MB base).

Use upstream kubectl instead of the OpenShift oc/kubectl bundle, which is twice the size (99 MB vs 49 MB). We don't use any oc-specific features when running remotely.

Fixes #150