### PR TITLE
gather: Make worker count configurable

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -40,6 +40,7 @@ func localGather(clusterConfigs []*clusterConfig) {
 			Namespaces: namespaces,
 			Addons:     addons,
 			Cluster:    cluster,
+			Workers:    workers,
 			Salt:       parsedSalt,
 			Log:        log.Named(clusterConfig.Context),
 		}

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -117,6 +117,10 @@ func mustGatherCommand(context string, directory string) *exec.Cmd {
 	// ensuring consistent hashes for comparing secrets across clusters.
 	remoteArgs = append(remoteArgs, "--salt="+salt)
 
+	if workers > 0 {
+		remoteArgs = append(remoteArgs, fmt.Sprintf("--workers=%d", workers))
+	}
+
 	if len(remoteArgs) > 0 {
 		args = append(args, "--", "/usr/bin/gather")
 		args = append(args, remoteArgs...)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var salt string
 var parsedSalt gather.Salt
 var verbose bool
 var logFormat string
+var workers int
 var mustGatherVersion bool
 var log *zap.SugaredLogger
 
@@ -107,6 +108,8 @@ func init() {
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
 		"be more verbose")
 	rootCmd.Flags().StringVar(&logFormat, "log-format", "text", "Set the logging format [text, json]")
+	rootCmd.Flags().IntVarP(&workers, "workers", "w", 0,
+		"number of parallel workers per work queue (default 6)")
 	rootCmd.Flags().BoolVar(&mustGatherVersion, "must-gather-version", false,
 		"print must-gather version info and exit")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,6 +170,10 @@ func runGather(cmd *cobra.Command, args []string) {
 		log.Infof("Using all addons")
 	}
 
+	if cmd.Flags().Changed("workers") {
+		log.Infof("Using %d workers per work queue", workers)
+	}
+
 	if !cmd.Flags().Changed("directory") {
 		log.Infof("Storing data in %q", directory)
 	}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -52,6 +52,7 @@ type Options struct {
 	Namespaces []string
 	Addons     []string
 	Cluster    bool
+	Workers    int
 	Salt       Salt
 	Log        *zap.SugaredLogger
 }
@@ -117,14 +118,19 @@ func New(config *rest.Config, directory string, opts Options) (*Gatherer, error)
 		opts.Salt = RandomSalt()
 	}
 
+	workers := opts.Workers
+	if workers < 1 {
+		workers = workQueueSize
+	}
+
 	g := &Gatherer{
 		config:       config,
 		httpClient:   httpClient,
 		client:       client,
 		output:       OutputDirectory{base: directory},
 		opts:         &opts,
-		gatherQueue:  NewWorkQueue(workQueueSize),
-		inspectQueue: NewWorkQueue(workQueueSize),
+		gatherQueue:  NewWorkQueue(workers),
+		inspectQueue: NewWorkQueue(workers),
 		log:          opts.Log,
 		resources:    make(map[string]struct{}),
 	}


### PR DESCRIPTION
Add --workers(-w) flag to control the number of parallel workers per work queue. This helps avoid overloading the cluster API server when gathering data. The flag is passed through to remote clusters as well.

Add Workers field to Options to allow callers to control the number of parallel workers per work queue. When not set or zero, the default of 6 workers is used.

On my minikube setup with rook-ceph cluster with 4 vcpus and 8 GiB RAM, running kubectl gather would result in loss of heartbeat for OSD and MON pods thereby resulting in HEALTH_WARN status in kubectl gather.

**BEFORE**
```
$ kubectl gather --contexts hub,dr1,dr2 -d drenv-installed
2026-04-14T16:04:29.541-0400    INFO    gather  Using kubeconfig "/home/rtalur/.local/share/tmux-kubeconfig/tmux-pane-26-kubeconfig"
2026-04-14T16:04:29.543-0400    INFO    gather  Using generated salt "HdkjRzmFvETpTVlHDY3Hug=="
2026-04-14T16:04:29.543-0400    INFO    gather  Gathering from all namespaces
2026-04-14T16:04:29.543-0400    INFO    gather  Gathering cluster scoped resources
2026-04-14T16:04:29.543-0400    INFO    gather  Using all addons
2026-04-14T16:04:29.543-0400    INFO    gather  Gathering from cluster "hub"
2026-04-14T16:04:29.543-0400    INFO    gather  Gathering from cluster "dr1"
2026-04-14T16:04:29.543-0400    INFO    gather  Gathering from cluster "dr2"
2026-04-14T16:05:25.313-0400    INFO    gather  Gathered 1231 resources from cluster "hub" in 55.770 seconds
2026-04-14T16:06:16.384-0400    INFO    gather  Gathered 1342 resources from cluster "dr1" in 106.840 seconds
2026-04-14T16:06:29.778-0400    INFO    gather  Gathered 1345 resources from cluster "dr2" in 120.235 seconds
2026-04-14T16:06:29.778-0400    INFO    gather  Gathered 3918 resources from 3 clusters in 120.235 seconds

$ grep -nri HEALTH_WARN drenv-installed/                                                                                                                
drenv-installed/dr2/namespaces/rook-ceph/ceph.rook.io/cephclusters/my-cluster.yaml:303:    previousHealth: HEALTH_WARN                                  
drenv-installed/dr2/addons/rook/commands/ceph-status:3:    health: HEALTH_WARN                                                                          
drenv-installed/dr1/namespaces/rook-ceph/ceph.rook.io/cephclusters/my-cluster.yaml:303:    previousHealth: HEALTH_WARN                                  
drenv-installed/dr1/addons/rook/commands/ceph-status:3:    health: HEALTH_WARN    
```

**AFTER**
```
$ kubectl gather --contexts hub,dr1,dr2 -d drenv-installed -w 1
2026-04-14T16:14:11.095-0400    INFO    gather  Using kubeconfig "/home/rtalur/.local/share/tmux-kubeconfig/tmux-pane-26-kubeconfig"
2026-04-14T16:14:11.101-0400    INFO    gather  Using generated salt "eF8xK7oFx25YSDV1He6Pqw=="
2026-04-14T16:14:11.101-0400    INFO    gather  Gathering from all namespaces
2026-04-14T16:14:11.101-0400    INFO    gather  Gathering cluster scoped resources
2026-04-14T16:14:11.101-0400    INFO    gather  Using all addons
2026-04-14T16:14:11.101-0400    INFO    gather  Using 1 workers per work queue
2026-04-14T16:14:11.101-0400    INFO    gather  Gathering from cluster "hub"
2026-04-14T16:14:11.101-0400    INFO    gather  Gathering from cluster "dr1"
2026-04-14T16:14:11.101-0400    INFO    gather  Gathering from cluster "dr2"
2026-04-14T16:14:49.622-0400    INFO    gather  Gathered 1239 resources from cluster "hub" in 38.521 seconds
2026-04-14T16:16:51.530-0400    INFO    gather  Gathered 1376 resources from cluster "dr2" in 160.429 seconds
2026-04-14T16:16:53.677-0400    INFO    gather  Gathered 1367 resources from cluster "dr1" in 162.576 seconds
2026-04-14T16:16:53.677-0400    INFO    gather  Gathered 3982 resources from 3 clusters in 162.576 seconds

$ grep -nri HEALTH_WARN drenv-installed/
drenv-installed/dr2/namespaces/rook-ceph/ceph.rook.io/cephclusters/my-cluster.yaml:303:    previousHealth: HEALTH_WARN
drenv-installed/dr1/namespaces/rook-ceph/ceph.rook.io/cephclusters/my-cluster.yaml:303:    previousHealth: HEALTH_WARN
```