### PR TITLE
remote: Remove redundant must-gather.log

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -50,17 +49,9 @@ func runMustGather(context string, directory string) error {
 	log.Infof("Gathering on remote cluster %q", context)
 	start := time.Now()
 
-	logfile, err := createMustGatherLog(directory)
-	if err != nil {
-		return err
-	}
-
-	defer logfile.Close()
-
 	var stderr bytes.Buffer
 
 	cmd := mustGatherCommand(context, directory)
-	cmd.Stdout = logfile
 	cmd.Stderr = &stderr
 
 	log.Debugf("Running command: %s", cmd)
@@ -73,14 +64,6 @@ func runMustGather(context string, directory string) error {
 		context, elapsed)
 
 	return nil
-}
-
-func createMustGatherLog(directory string) (*os.File, error) {
-	if err := os.MkdirAll(directory, 0750); err != nil {
-		return nil, err
-	}
-
-	return os.Create(filepath.Join(directory, "must-gather.log"))
 }
 
 func mustGatherCommand(context string, directory string) *exec.Cmd {


### PR DESCRIPTION
oc adm must-gather already creates must-gather.logs with the harness
output. Our must-gather.log was a near-duplicate capturing oc's stdout,
differing only by including pod log lines and microsecond timestamp
variations.

The gather plugin's own detailed log is available in gather.log inside
the plugin output directory, so no useful information is lost.

Example directory layout:

```console
% tree -h -L3 e2e/out/test-gather-remote/
[ 160]  e2e/out/test-gather-remote/
├── [ 192]  c1
│   ├── [ 224]  docker-sha256-33ebe2e933d54d3c886f41ea9d1bae436af073c5ac327fa2d751e58e84ad533a
│   │   ├── [ 384]  cluster
│   │   ├── [ 14K]  gather.log
│   │   ├── [ 957]  gather.logs
│   │   ├── [ 288]  namespaces
│   │   └── [  22]  version
│   ├── [3.3K]  event-filter.html
│   ├── [ 54K]  must-gather.logs
│   └── [ 104]  timestamp
├── [ 192]  c2
│   ├── [ 224]  docker-sha256-33ebe2e933d54d3c886f41ea9d1bae436af073c5ac327fa2d751e58e84ad533a
│   │   ├── [ 384]  cluster
│   │   ├── [ 14K]  gather.log
│   │   ├── [ 957]  gather.logs
│   │   ├── [ 288]  namespaces
│   │   └── [  22]  version
│   ├── [3.3K]  event-filter.html
│   ├── [ 54K]  must-gather.logs
│   └── [ 105]  timestamp
└── [1.3K]  gather.log
```

Notes:
- out/gather.log is our detailed log created on the cluster
- out/cluster/must-gather.logs is created by `oc adm must-gather`
- out/cluster/docker-sha256-digest/gather.logs is gather pod stdout captured by must-gather
