### PR TITLE
ci: Simplify unit test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,11 +122,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        exclude:
-          - goarch: arm64
-            goos: windows
         include:
           - goos: linux
             goarch: amd64


### PR DESCRIPTION
Since we need to specify the full include list, goos, goarch, and exclude are not useful.