### PR TITLE
e2e: Extract minikube package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,4 +165,4 @@ e2e-container: e2e-clusters
 	mkdir -p e2e/out
 	rm -f e2e/out/gather.tar
 	podman save -o e2e/out/gather.tar $(e2e_image)
-	cd e2e && go run ./cmd load out/gather.tar
+	go run ./e2e/cmd load e2e/out/gather.tar

--- a/e2e/clusters/clusters.go
+++ b/e2e/clusters/clusters.go
@@ -1,17 +1,11 @@
 package clusters
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"os/exec"
-	"runtime"
 	"sync"
 
-	"github.com/nirs/kubectl-gather/e2e/commands"
+	"github.com/nirs/kubectl-gather/e2e/clusters/minikube"
 )
 
 const (
@@ -23,7 +17,7 @@ var Names = []string{C1, C2}
 
 func Create() error {
 	log.Print("Creating clusters")
-	profiles, err := profilesStatus()
+	profiles, err := minikube.ClustersStatus()
 	if err != nil {
 		return err
 	}
@@ -39,7 +33,9 @@ func Create() error {
 			return fmt.Errorf("cluster %q status is %q", name, status)
 		}
 	}
-	if err := execute(createCluster, start); err != nil {
+	if err := execute(func(name string) error {
+		return minikube.New(name).Create()
+	}, start); err != nil {
 		return err
 	}
 	log.Print("Clusters created")
@@ -48,7 +44,9 @@ func Create() error {
 
 func Delete() error {
 	log.Print("Deleting clusters")
-	if err := execute(deleteCluster, Names); err != nil {
+	if err := execute(func(name string) error {
+		return minikube.New(name).Delete()
+	}, Names); err != nil {
 		return err
 	}
 	log.Print("Clusters deleted")
@@ -58,7 +56,7 @@ func Delete() error {
 func Load(archive string) error {
 	log.Printf("Loading image %q", archive)
 	if err := execute(func(name string) error {
-		return runMinikube(name, "image", "load", archive)
+		return minikube.New(name).Load(archive)
 	}, Names); err != nil {
 		return err
 	}
@@ -83,135 +81,6 @@ func execute(fn func(name string) error, names []string) error {
 	close(errors)
 	for e := range errors {
 		return e
-	}
-	return nil
-}
-
-func createCluster(name string) error {
-	if err := startCluster(name); err != nil {
-		return err
-	}
-	if runtime.GOOS == "darwin" {
-		if err := configureDNS(name); err != nil {
-			return err
-		}
-		if err := verifyDNS(name); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteCluster(name string) error {
-	log.Printf("Deleting cluster %q", name)
-	return runMinikube(name, "delete")
-}
-
-// startCluster start the minikube cluster, creating it if it does not exist.
-func startCluster(name string) error {
-	log.Printf("Start cluster %q", name)
-	args := []string{"start", "--memory", "3g"}
-	switch runtime.GOOS {
-	case "darwin":
-		args = append(args, "--driver", "vfkit", "--network", "vmnet-shared")
-	case "linux":
-		args = append(args, "--driver", "docker")
-	}
-	return runMinikube(name, args...)
-}
-
-// configureDNS configure the cluster to use public DNS server. Required only on
-// managed macOS machines, but harmless on unmanaged machines.
-//
-// On managed Macs, corporate security agents install network extensions that
-// silently discard DNS traffic from the vmnet bridge (192.168.105.0/24).
-// However, DNS traffic to public servers (e.g., 8.8.8.8) is forwarded via NAT
-// normally.
-//
-// We configure systemd-resolved in the minikube VM with two settings:
-//
-//  1. Public DNS servers that are reachable from the VM, bypassing the host's
-//     broken DNS path.
-//
-//  2. Routing domain (eth0 "~.") The "~." syntax tells systemd-resolved to
-//     route ALL DNS queries through eth0's DNS servers.  Without this,
-//     systemd-resolved might still try other interfaces' DNS servers.
-func configureDNS(name string) error {
-	log.Printf("Configuring DNS in cluster %q", name)
-	script := `\
-resolvectl dns eth0 8.8.8.8 1.1.1.1
-resolvectl domain eth0 "~."
-resolvectl flush-caches`
-	command := fmt.Sprintf("sudo bash -o errexit -c '%s'", script)
-	return runMinikube(name, "ssh", "--", command)
-}
-
-// verifyDNS ensures that DNS works in the cluster, failing if not. Required on
-// managed macOS machines to verify that our configuration works. Does not work
-// on non-vm drivers on Linux.
-func verifyDNS(name string) error {
-	log.Printf("Verifying DNS in cluster %q", name)
-	return runMinikube(name, "ssh", "--", "resolvectl", "query", "google.com")
-}
-
-type profileInfo struct {
-	Name   string
-	Status string
-}
-
-type profileList struct {
-	Valid   []profileInfo `json:"valid"`
-	Invalid []profileInfo `json:"invalid"`
-}
-
-func profilesStatus() (map[string]string, error) {
-	status := map[string]string{}
-	cmd := exec.Command("minikube", "profile", "list", "--output", "json")
-	log.Printf("Running %v", cmd)
-	out, err := cmd.Output()
-	if err != nil {
-		return status, fmt.Errorf("failed to list profiles: %w: %s", err, commands.Stderr(err))
-	}
-	profiles := profileList{}
-	if err := json.Unmarshal(out, &profiles); err != nil {
-		return status, fmt.Errorf("failed to unmarshal profile list: %w", err)
-	}
-	for _, profile := range profiles.Valid {
-		status[profile.Name] = profile.Status
-	}
-	for _, profile := range profiles.Invalid {
-		status[profile.Name] = profile.Status
-	}
-	return status, nil
-}
-
-func runMinikube(name string, args ...string) error {
-	cmd_args := []string{"--profile", name}
-	cmd_args = append(cmd_args, args...)
-	cmd := exec.Command("minikube", cmd_args...)
-	log.Printf("[%s] Running %s", name, cmd)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	pipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	reader := bufio.NewReader(pipe)
-	for {
-		line, _, err := reader.ReadLine()
-		if err != nil {
-			if err != io.EOF {
-				log.Printf("[%s] Failed to read from command stdout: %s", name, err)
-			}
-			break
-		}
-		log.Printf("[%s] %s", name, string(line))
-	}
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("%w: %s", err, stderr.String())
 	}
 	return nil
 }

--- a/e2e/clusters/minikube/minikube.go
+++ b/e2e/clusters/minikube/minikube.go
@@ -1,0 +1,166 @@
+package minikube
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"runtime"
+	"sync"
+
+	"github.com/nirs/kubectl-gather/e2e/commands"
+)
+
+type Cluster struct {
+	Name string
+}
+
+type profileInfo struct {
+	Name   string
+	Status string
+}
+
+type profileList struct {
+	Valid   []profileInfo `json:"valid"`
+	Invalid []profileInfo `json:"invalid"`
+}
+
+func ClustersStatus() (map[string]string, error) {
+	status := map[string]string{}
+	cmd := exec.Command("minikube", "profile", "list", "--output", "json")
+	log.Printf("Running %v", cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return status, fmt.Errorf("failed to list profiles: %w: %s", err, commands.Stderr(err))
+	}
+	profiles := profileList{}
+	if err := json.Unmarshal(out, &profiles); err != nil {
+		return status, fmt.Errorf("failed to unmarshal profile list: %w", err)
+	}
+	for _, profile := range profiles.Valid {
+		status[profile.Name] = profile.Status
+	}
+	for _, profile := range profiles.Invalid {
+		status[profile.Name] = profile.Status
+	}
+	return status, nil
+}
+
+func New(name string) *Cluster {
+	return &Cluster{name}
+}
+
+func (c *Cluster) Create() error {
+	log.Printf("Creating cluster %q", c.Name)
+	if err := c.startCluster(); err != nil {
+		return err
+	}
+	if runtime.GOOS == "darwin" {
+		if err := c.configureDNS(); err != nil {
+			return err
+		}
+		if err := c.verifyDNS(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteMutex serializes delete operations to work around minikube not locking
+// ~/.kube/config during cleanup. Without this, concurrent deletes race and
+// one leaves stale kubeconfig entries.
+var deleteMutex sync.Mutex
+
+func (c *Cluster) Delete() error {
+	deleteMutex.Lock()
+	defer deleteMutex.Unlock()
+	log.Printf("Deleting cluster %q", c.Name)
+	return c.run("delete")
+}
+
+func (c *Cluster) Load(archive string) error {
+	log.Printf("Loading image %q in cluster %q", archive, c.Name)
+	return c.run("image", "load", archive)
+}
+
+// startCluster start the minikube cluster, creating it if it does not exist.
+func (c *Cluster) startCluster() error {
+	log.Printf("Start cluster %q", c.Name)
+	args := []string{"start", "--memory", "3g"}
+	switch runtime.GOOS {
+	case "darwin":
+		args = append(args, "--driver", "vfkit", "--network", "vmnet-shared")
+	case "linux":
+		args = append(args, "--driver", "docker")
+	}
+	return c.run(args...)
+}
+
+// configureDNS configure the cluster to use public DNS server. Required only on
+// managed macOS machines, but harmless on unmanaged machines.
+//
+// On managed Macs, corporate security agents install network extensions that
+// silently discard DNS traffic from the vmnet bridge (192.168.105.0/24).
+// However, DNS traffic to public servers (e.g., 8.8.8.8) is forwarded via NAT
+// normally.
+//
+// We configure systemd-resolved in the minikube VM with two settings:
+//
+//  1. Public DNS servers that are reachable from the VM, bypassing the host's
+//     broken DNS path.
+//
+//  2. Routing domain (eth0 "~.") The "~." syntax tells systemd-resolved to
+//     route ALL DNS queries through eth0's DNS servers.  Without this,
+//     systemd-resolved might still try other interfaces' DNS servers.
+func (c *Cluster) configureDNS() error {
+	log.Printf("Configuring DNS in cluster %q", c.Name)
+	script := `\
+resolvectl dns eth0 8.8.8.8 1.1.1.1
+resolvectl domain eth0 "~."
+resolvectl flush-caches`
+	command := fmt.Sprintf("sudo bash -o errexit -c '%s'", script)
+	return c.run("ssh", "--", command)
+}
+
+// verifyDNS ensures that DNS works in the cluster, failing if not. Required on
+// managed macOS machines to verify that our configuration works. Does not work
+// on non-vm drivers on Linux.
+func (c *Cluster) verifyDNS() error {
+	log.Printf("Verifying DNS in cluster %q", c.Name)
+	return c.run("ssh", "--", "resolvectl", "query", "google.com")
+}
+
+// run executes a minikube command, streaming stdout to the log.
+func (c *Cluster) run(args ...string) error {
+	args = append([]string{"--profile", c.Name}, args...)
+	cmd := exec.Command("minikube", args...)
+	log.Printf("[%s] Running %s", c.Name, cmd)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(pipe)
+	for {
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("[%s] Failed to read from command stdout: %s", c.Name, err)
+			}
+			break
+		}
+		log.Printf("[%s] %s", c.Name, string(line))
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}


### PR DESCRIPTION
Move all minikube-specific logic (command execution, profile querying,
DNS configuration) into a dedicated e2e/clusters/minikube package behind
a Cluster struct. The clusters package becomes a thin orchestration
layer that manages parallel execution across named clusters.

This separates the "which clusters to manage" concern from the "how to
manage them via minikube" concern, making it easier to swap in a
different cluster provider in the future without changing the
orchestration logic.

The Cluster struct approach (minikube.New(name).Action()) supports
adding per-cluster options later (e.g., driver, memory) without growing
function parameter lists.