### PR TITLE
go: Update toolchain to go1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nirs/kubectl-gather
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/aymanbagabas/go-udiff v0.4.1


### PR DESCRIPTION
To consume latest fixes.

Fixes #156