### PR TITLE
Improve E2E logging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,10 @@ jobs:
       - name: Archive test artifacts
         if: always()
         run: |
-          find e2e/out -maxdepth 1 -name 'test-*' > artifacts.txt
+          find e2e/out -maxdepth 1 \
+              -name 'test-*' -print -o \
+              -name '*.log' -print \
+              > artifacts.txt
           tar --create \
               --gzip \
               --file kubectl-gather-e2e-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,6 +92,9 @@ jobs:
           oc version --client
       - name: Run e2e tests
         run: make e2e-tests
+      - name: Delete clusters
+        if: always()
+        run: make clean
       # Tar manually to work around github limitations with special characters
       # (:) in file names, and getting much smaller archives compared with zip.
       # https://github.com/actions/upload-artifact/issues/546
@@ -115,9 +118,6 @@ jobs:
           path: kubectl-gather-e2e-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
           compression-level: 0
           retention-days: 15
-      - name: Delete clusters
-        if: always()
-        run: make clean
 
   unit-test-matrix:
     name: Unit test (${{ matrix.goos }}-${{ matrix.goarch }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,38 @@ Fork the project in github and clone the source:
 git clone https://github.com/{my-github-username}/kubectl-gather.git
 ```
 
+## Editor setup
+
+The e2e test files use the `//go:build e2e` build tag. You need to
+configure your editor's Go language server to recognize this tag,
+otherwise it will report errors for the `e2e` package.
+
+### Cursor / VSCode
+
+Create `.vscode/settings.json` in the project root:
+
+```json
+{
+  "gopls": {
+    "build.buildFlags": ["-tags=e2e"]
+  }
+}
+```
+
+### Vim / Neovim (with gopls)
+
+Add to your gopls configuration:
+
+```lua
+require('lspconfig').gopls.setup({
+  settings = {
+    gopls = {
+      buildFlags = { "-tags=e2e" },
+    },
+  },
+})
+```
+
 ## Build
 
 ```console
@@ -108,6 +140,12 @@ make e2e-tests
 
 This creates clusters, deploys test workloads, and runs all tests. On
 subsequent runs, existing clusters are reused.
+
+To run a specific e2e test directly:
+
+```console
+go test -tags e2e ./e2e -v -count=1 -run TestGatherLocal
+```
 
 ## Build a container image
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,11 +117,15 @@ Run all tests:
 make test
 ```
 
-To clean up:
+To delete clusters:
 
 ```console
 make clean
 ```
+
+> [!TIP]
+> Test output and logs are kept in `e2e/out` for inspection after the
+> run. Delete it manually with `rm -rf e2e/out` when no longer needed.
 
 ### Running specific tests
 

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ lint:
 test: unit-tests e2e-tests
 
 unit-tests:
-	go test -v -count=1 ./pkg/gather ./e2e/test
+	go test -v -count=1 ./...
 
 e2e-tests: e2e-build e2e-deploy e2e-container
 	rm -rf e2e/out/test-*
-	go test ./e2e -v -count=1
+	go test -tags e2e ./e2e -v -count=1
 
 clean:
 	go run ./e2e/cmd delete

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ e2e-tests: e2e-build e2e-deploy e2e-container
 
 clean:
 	go run ./e2e/cmd delete
-	rm -rf e2e/out
 
 # Build container image locally. Uses qemu emulation for non-native platforms.
 container:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lint:
 test: unit-tests e2e-tests
 
 unit-tests:
-	go test -v -count=1 ./pkg/gather
+	go test -v -count=1 ./pkg/gather ./e2e/test
 
 e2e-tests: e2e-build e2e-deploy e2e-container
 	rm -rf e2e/out/test-*

--- a/e2e/clusters/clusters.go
+++ b/e2e/clusters/clusters.go
@@ -2,8 +2,9 @@ package clusters
 
 import (
 	"fmt"
-	"log"
 	"sync"
+
+	"go.uber.org/zap"
 
 	"github.com/nirs/kubectl-gather/e2e/clusters/minikube"
 )
@@ -15,9 +16,9 @@ const (
 
 var Names = []string{C1, C2}
 
-func Create() error {
-	log.Print("Creating clusters")
-	profiles, err := minikube.ClustersStatus()
+func Create(log *zap.SugaredLogger) error {
+	log.Debug("Creating clusters")
+	profiles, err := minikube.ClustersStatus(log)
 	if err != nil {
 		return err
 	}
@@ -26,7 +27,7 @@ func Create() error {
 		status := profiles[name]
 		switch status {
 		case "OK", "Running":
-			log.Printf("Using existing cluster %q", name)
+			log.Debugf("Using existing cluster %q", name)
 		case "", "Stopped":
 			start = append(start, name)
 		default:
@@ -34,33 +35,33 @@ func Create() error {
 		}
 	}
 	if err := execute(func(name string) error {
-		return minikube.New(name).Create()
+		return minikube.New(name, log).Create()
 	}, start); err != nil {
 		return err
 	}
-	log.Print("Clusters created")
+	log.Debug("Clusters created")
 	return nil
 }
 
-func Delete() error {
-	log.Print("Deleting clusters")
+func Delete(log *zap.SugaredLogger) error {
+	log.Debug("Deleting clusters")
 	if err := execute(func(name string) error {
-		return minikube.New(name).Delete()
+		return minikube.New(name, log).Delete()
 	}, Names); err != nil {
 		return err
 	}
-	log.Print("Clusters deleted")
+	log.Debug("Clusters deleted")
 	return nil
 }
 
-func Load(archive string) error {
-	log.Printf("Loading image %q", archive)
+func Load(log *zap.SugaredLogger, archive string) error {
+	log.Debugf("Loading image %q", archive)
 	if err := execute(func(name string) error {
-		return minikube.New(name).Load(archive)
+		return minikube.New(name, log).Load(archive)
 	}, Names); err != nil {
 		return err
 	}
-	log.Print("Image loaded")
+	log.Debug("Image loaded")
 	return nil
 }
 

--- a/e2e/clusters/minikube/minikube.go
+++ b/e2e/clusters/minikube/minikube.go
@@ -6,16 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os/exec"
 	"runtime"
 	"sync"
+
+	"go.uber.org/zap"
 
 	"github.com/nirs/kubectl-gather/e2e/commands"
 )
 
 type Cluster struct {
 	Name string
+	log  *zap.SugaredLogger
 }
 
 type profileInfo struct {
@@ -28,10 +30,10 @@ type profileList struct {
 	Invalid []profileInfo `json:"invalid"`
 }
 
-func ClustersStatus() (map[string]string, error) {
+func ClustersStatus(log *zap.SugaredLogger) (map[string]string, error) {
 	status := map[string]string{}
 	cmd := exec.Command("minikube", "profile", "list", "--output", "json")
-	log.Printf("Running %v", cmd)
+	log.Debugf("Running %v", cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return status, fmt.Errorf("failed to list profiles: %w: %s", err, commands.Stderr(err))
@@ -49,12 +51,15 @@ func ClustersStatus() (map[string]string, error) {
 	return status, nil
 }
 
-func New(name string) *Cluster {
-	return &Cluster{name}
+func New(name string, log *zap.SugaredLogger) *Cluster {
+	return &Cluster{
+		Name: name,
+		log:  log.Named(name),
+	}
 }
 
 func (c *Cluster) Create() error {
-	log.Printf("Creating cluster %q", c.Name)
+	c.log.Info("Creating cluster")
 	if err := c.startCluster(); err != nil {
 		return err
 	}
@@ -77,18 +82,18 @@ var deleteMutex sync.Mutex
 func (c *Cluster) Delete() error {
 	deleteMutex.Lock()
 	defer deleteMutex.Unlock()
-	log.Printf("Deleting cluster %q", c.Name)
+	c.log.Info("Deleting cluster")
 	return c.run("delete")
 }
 
 func (c *Cluster) Load(archive string) error {
-	log.Printf("Loading image %q in cluster %q", archive, c.Name)
+	c.log.Infof("Loading image %q", archive)
 	return c.run("image", "load", archive)
 }
 
 // startCluster start the minikube cluster, creating it if it does not exist.
 func (c *Cluster) startCluster() error {
-	log.Printf("Start cluster %q", c.Name)
+	c.log.Info("Starting cluster")
 	args := []string{"start", "--memory", "3g"}
 	switch runtime.GOOS {
 	case "darwin":
@@ -116,7 +121,7 @@ func (c *Cluster) startCluster() error {
 //     route ALL DNS queries through eth0's DNS servers.  Without this,
 //     systemd-resolved might still try other interfaces' DNS servers.
 func (c *Cluster) configureDNS() error {
-	log.Printf("Configuring DNS in cluster %q", c.Name)
+	c.log.Info("Configuring DNS")
 	script := `\
 resolvectl dns eth0 8.8.8.8 1.1.1.1
 resolvectl domain eth0 "~."
@@ -129,7 +134,7 @@ resolvectl flush-caches`
 // managed macOS machines to verify that our configuration works. Does not work
 // on non-vm drivers on Linux.
 func (c *Cluster) verifyDNS() error {
-	log.Printf("Verifying DNS in cluster %q", c.Name)
+	c.log.Info("Verifying DNS")
 	return c.run("ssh", "--", "resolvectl", "query", "google.com")
 }
 
@@ -137,7 +142,7 @@ func (c *Cluster) verifyDNS() error {
 func (c *Cluster) run(args ...string) error {
 	args = append([]string{"--profile", c.Name}, args...)
 	cmd := exec.Command("minikube", args...)
-	log.Printf("[%s] Running %s", c.Name, cmd)
+	c.log.Debugf("Running %s", cmd)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -153,11 +158,11 @@ func (c *Cluster) run(args ...string) error {
 		line, _, err := reader.ReadLine()
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("[%s] Failed to read from command stdout: %s", c.Name, err)
+				c.log.Debugf("Failed to read from command stdout: %s", err)
 			}
 			break
 		}
-		log.Printf("[%s] %s", c.Name, string(line))
+		c.log.Debug(string(line))
 	}
 	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("%w: %s", err, stderr.String())

--- a/e2e/cmd/main.go
+++ b/e2e/cmd/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os"
 
-	"github.com/nirs/kubectl-gather/e2e/clusters"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/nirs/kubectl-gather/e2e/clusters"
+	"github.com/nirs/kubectl-gather/e2e/logging"
 )
+
+var log *zap.SugaredLogger
 
 var rootCmd = &cobra.Command{
 	Use:   "e2e",
@@ -17,7 +22,7 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create the e2e environment",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := clusters.Create(); err != nil {
+		if err := clusters.Create(log); err != nil {
 			log.Fatal(err)
 		}
 	},
@@ -28,7 +33,7 @@ var loadCmd = &cobra.Command{
 	Short: "Load image archive into e2e clusters",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := clusters.Load(args[0]); err != nil {
+		if err := clusters.Load(log, args[0]); err != nil {
 			log.Fatal(err)
 		}
 	},
@@ -38,7 +43,7 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete the e2e environment",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := clusters.Delete(); err != nil {
+		if err := clusters.Delete(log); err != nil {
 			log.Fatal(err)
 		}
 	},
@@ -51,8 +56,14 @@ func init() {
 }
 
 func main() {
-	err := rootCmd.Execute()
+	var err error
+	log, err = logging.NewLogger()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = log.Sync() }()
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/e2e/commands/commands.go
+++ b/e2e/commands/commands.go
@@ -3,13 +3,14 @@ package commands
 import (
 	"bufio"
 	"io"
-	"log"
 	"os/exec"
+
+	"go.uber.org/zap"
 )
 
 // Run a command logging lines from stderr.
-func Run(cmd *exec.Cmd) error {
-	log.Printf("Running %v", cmd)
+func Run(cmd *exec.Cmd, log *zap.SugaredLogger) error {
+	log.Debugf("Running %v", cmd)
 	pipe, err := cmd.StderrPipe()
 	if err != nil {
 		return err
@@ -22,11 +23,11 @@ func Run(cmd *exec.Cmd) error {
 		line, _, err := reader.ReadLine()
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("Failed to read from command stderr: %s", err)
+				log.Debugf("Failed to read from command stderr: %s", err)
 			}
 			break
 		}
-		log.Print(string(line))
+		log.Debug(string(line))
 	}
 	return cmd.Wait()
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -4,7 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"testing"
+
+	"github.com/nirs/kubectl-gather/e2e/test"
 )
 
 const kubectlGather = "../kubectl-gather"
@@ -16,7 +17,7 @@ const kubectlGather = "../kubectl-gather"
 //
 // The directory is verified by checking that it contains a version file
 // matching the output of kubectl-gather --must-gather-version.
-func findDataRoot(t *testing.T, clusterDir string) string {
+func findDataRoot(t *test.T, clusterDir string) string {
 	t.Helper()
 
 	pattern := filepath.Join(clusterDir, "*sha256-*", "version")

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nirs/kubectl-gather/e2e/clusters"
 	"github.com/nirs/kubectl-gather/e2e/commands"
+	"github.com/nirs/kubectl-gather/e2e/test"
 	"github.com/nirs/kubectl-gather/e2e/validate"
 )
 
@@ -91,7 +92,8 @@ var (
 	}
 )
 
-func TestGatherLocal(t *testing.T) {
+func TestGatherLocal(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-local"
 
 	cmd := exec.Command(
@@ -99,14 +101,15 @@ func TestGatherLocal(t *testing.T) {
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
 	validateGatherAll(t, validate.New(outputDir))
 }
 
-func TestGatherClusterTrue(t *testing.T) {
+func TestGatherClusterTrue(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-cluster-true"
 
 	cmd := exec.Command(
@@ -115,14 +118,15 @@ func TestGatherClusterTrue(t *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
 	validateGatherAll(t, validate.New(outputDir))
 }
 
-func TestGatherRemote(t *testing.T) {
+func TestGatherRemote(dt *testing.T) {
+	t := test.WithLog(dt)
 	if _, err := exec.LookPath("oc"); err != nil {
 		t.Skip("oc not found, skipping remote test")
 	}
@@ -135,17 +139,18 @@ func TestGatherRemote(t *testing.T) {
 		"--remote",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Fatalf("kubectl-gather --remote failed: %s", err)
 	}
 
 	dataRoot := findDataRoot(t, filepath.Join(outputDir, clusters.C1))
-	t.Logf("Data root: %s", dataRoot)
+	t.Debugf("Data root: %s", dataRoot)
 
 	validateGatherAll(t, validate.New(outputDir).WithDataRoot(dataRoot))
 }
 
-func TestGatherClusterFalse(t *testing.T) {
+func TestGatherClusterFalse(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-cluster-false"
 
 	cmd := exec.Command(
@@ -154,7 +159,7 @@ func TestGatherClusterFalse(t *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -194,7 +199,8 @@ func TestGatherClusterFalse(t *testing.T) {
 	)
 }
 
-func TestGatherEmptyNamespaces(t *testing.T) {
+func TestGatherEmptyNamespaces(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-empty-namespaces"
 
 	cmd := exec.Command(
@@ -203,14 +209,15 @@ func TestGatherEmptyNamespaces(t *testing.T) {
 		"--namespaces=", "",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err == nil {
+	if err := commands.Run(cmd, t.Log); err == nil {
 		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
 	validateNoClusterDir(t, outputDir)
 }
 
-func TestGatherEmptyNamespacesClusterFalse(t *testing.T) {
+func TestGatherEmptyNamespacesClusterFalse(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-empty-namespaces-cluster-false"
 
 	cmd := exec.Command(
@@ -220,14 +227,15 @@ func TestGatherEmptyNamespacesClusterFalse(t *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err == nil {
+	if err := commands.Run(cmd, t.Log); err == nil {
 		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
 	validateNoClusterDir(t, outputDir)
 }
 
-func TestGatherEmptyNamespacesClusterTrue(t *testing.T) {
+func TestGatherEmptyNamespacesClusterTrue(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-empty-namespaces-cluster-true"
 
 	cmd := exec.Command(
@@ -237,7 +245,7 @@ func TestGatherEmptyNamespacesClusterTrue(t *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -277,7 +285,8 @@ func TestGatherEmptyNamespacesClusterTrue(t *testing.T) {
 	)
 }
 
-func TestGatherSpecificNamespaces(t *testing.T) {
+func TestGatherSpecificNamespaces(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-specific-namespaces"
 
 	cmd := exec.Command(
@@ -286,14 +295,15 @@ func TestGatherSpecificNamespaces(t *testing.T) {
 		"--namespaces", "test-common,test-c1",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
 	validateSpecificNamespaces(t, validate.New(outputDir))
 }
 
-func TestGatherSpecificNamespacesClusterFalse(t *testing.T) {
+func TestGatherSpecificNamespacesClusterFalse(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-specific-namespaces-cluster-false"
 
 	cmd := exec.Command(
@@ -303,14 +313,15 @@ func TestGatherSpecificNamespacesClusterFalse(t *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
 	validateSpecificNamespaces(t, validate.New(outputDir))
 }
 
-func TestGatherSpecificNamespacesClusterTrue(t *testing.T) {
+func TestGatherSpecificNamespacesClusterTrue(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-specific-namespaces-cluster-true"
 
 	cmd := exec.Command(
@@ -320,7 +331,7 @@ func TestGatherSpecificNamespacesClusterTrue(t *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -354,7 +365,8 @@ func TestGatherSpecificNamespacesClusterTrue(t *testing.T) {
 	)
 }
 
-func TestGatherAddonsLogs(t *testing.T) {
+func TestGatherAddonsLogs(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-addons-logs"
 
 	cmd := exec.Command(
@@ -364,7 +376,7 @@ func TestGatherAddonsLogs(t *testing.T) {
 		"--addons", "logs",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -399,7 +411,8 @@ func TestGatherAddonsLogs(t *testing.T) {
 	)
 }
 
-func TestGatherAddonsPVCs(t *testing.T) {
+func TestGatherAddonsPVCs(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-addons-pvcs"
 
 	cmd := exec.Command(
@@ -409,7 +422,7 @@ func TestGatherAddonsPVCs(t *testing.T) {
 		"--addons", "pvcs",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -441,7 +454,8 @@ func TestGatherAddonsPVCs(t *testing.T) {
 	)
 }
 
-func TestGatherAddonsEmpty(t *testing.T) {
+func TestGatherAddonsEmpty(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-gather-addons-empty"
 
 	cmd := exec.Command(
@@ -451,7 +465,7 @@ func TestGatherAddonsEmpty(t *testing.T) {
 		"--addons=",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -489,7 +503,8 @@ func TestGatherAddonsEmpty(t *testing.T) {
 	)
 }
 
-func TestJSONLogs(t *testing.T) {
+func TestJSONLogs(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-json-logs"
 	logPath := filepath.Join(outputDir, "gather.log")
 
@@ -499,7 +514,7 @@ func TestJSONLogs(t *testing.T) {
 		"--directory", outputDir,
 		"--log-format", "json",
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Errorf("kubectl-gather failed: %s", err)
 	}
 
@@ -508,7 +523,7 @@ func TestJSONLogs(t *testing.T) {
 
 // Test helpers
 
-func validateGatherAll(t *testing.T, v *validate.Validator) {
+func validateGatherAll(t *test.T, v *validate.Validator) {
 	t.Helper()
 
 	v.Exists(t, clusters.Names,
@@ -552,7 +567,7 @@ func validateGatherAll(t *testing.T, v *validate.Validator) {
 	)
 }
 
-func validateSpecificNamespaces(t *testing.T, v *validate.Validator) {
+func validateSpecificNamespaces(t *test.T, v *validate.Validator) {
 	t.Helper()
 
 	v.Exists(t, clusters.Names,
@@ -575,7 +590,7 @@ func validateSpecificNamespaces(t *testing.T, v *validate.Validator) {
 	)
 }
 
-func validateNoClusterDir(t *testing.T, outputDir string) {
+func validateNoClusterDir(t *test.T, outputDir string) {
 	for _, cluster := range clusters.Names {
 		clusterDir := filepath.Join(outputDir, cluster)
 		if validate.PathExists(t, clusterDir) {

--- a/e2e/logging/logging.go
+++ b/e2e/logging/logging.go
@@ -1,0 +1,62 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const loggerName = "e2e"
+
+// CreateLogger creates a logger that writes debug output to e2e/out/e2e.log
+// and minimal info messages to stderr. Must be called from the project root.
+func NewLogger() (*zap.SugaredLogger, error) {
+	fileCore, err := createFileCore("e2e/out/e2e.log")
+	if err != nil {
+		return nil, err
+	}
+	core := zapcore.NewTee(fileCore, createConsoleCore())
+	return zap.New(core).Named(loggerName).Sugar(), nil
+}
+
+// CreateTestLogger creates a logger that writes debug output to out/e2e.log
+// only, keeping the test console output clean. Must be called from the e2e
+// package directory (go test runs from the package directory).
+func NewTestLogger() (*zap.SugaredLogger, error) {
+	core, err := createFileCore("out/e2e.log")
+	if err != nil {
+		return nil, err
+	}
+	return zap.New(core).Named(loggerName).Sugar(), nil
+}
+
+func createFileCore(logFile string) (zapcore.Core, error) {
+	if err := os.MkdirAll(filepath.Dir(logFile), 0700); err != nil {
+		return nil, fmt.Errorf("cannot create log directory: %w", err)
+	}
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open log file: %w", err)
+	}
+	config := zap.NewProductionEncoderConfig()
+	config.EncodeTime = zapcore.ISO8601TimeEncoder
+	config.EncodeLevel = zapcore.CapitalLevelEncoder
+	encoder := zapcore.NewConsoleEncoder(config)
+	return zapcore.NewCore(encoder, zapcore.Lock(f), zapcore.DebugLevel), nil
+}
+
+func createConsoleCore() zapcore.Core {
+	config := zap.NewProductionEncoderConfig()
+	config.TimeKey = zapcore.OmitKey
+	config.CallerKey = zapcore.OmitKey
+	config.StacktraceKey = zapcore.OmitKey
+	config.EncodeLevel = zapcore.CapitalLevelEncoder
+	return zapcore.NewCore(
+		zapcore.NewConsoleEncoder(config),
+		zapcore.Lock(os.Stderr),
+		zapcore.InfoLevel,
+	)
+}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/nirs/kubectl-gather/e2e/test"
+)
+
+func TestMain(m *testing.M) {
+	test.Main(m)
+}

--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -14,11 +14,13 @@ import (
 
 	"github.com/nirs/kubectl-gather/e2e/clusters"
 	"github.com/nirs/kubectl-gather/e2e/commands"
+	"github.com/nirs/kubectl-gather/e2e/test"
 	"github.com/nirs/kubectl-gather/pkg/gather"
 )
 
 func TestOutput(t *testing.T) {
-	t.Run("local", func(t *testing.T) {
+	t.Run("local", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		outputDir := "out/test-output-local"
 
 		cmd := exec.Command(
@@ -26,7 +28,7 @@ func TestOutput(t *testing.T) {
 			"--contexts", clusters.C1,
 			"--directory", outputDir,
 		)
-		if err := commands.Run(cmd); err != nil {
+		if err := commands.Run(cmd, t.Log); err != nil {
 			t.Fatal(err)
 		}
 
@@ -34,7 +36,8 @@ func TestOutput(t *testing.T) {
 		testOutputReader(t, reader)
 	})
 
-	t.Run("remote", func(t *testing.T) {
+	t.Run("remote", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		if _, err := exec.LookPath("oc"); err != nil {
 			t.Skip("oc not found, skipping remote test")
 		}
@@ -48,22 +51,23 @@ func TestOutput(t *testing.T) {
 			"--remote",
 			"--directory", outputDir,
 		)
-		if err := commands.Run(cmd); err != nil {
+		if err := commands.Run(cmd, t.Log); err != nil {
 			t.Fatal(err)
 		}
 
 		dataRoot := findDataRoot(t, filepath.Join(outputDir, clusters.C1))
-		t.Logf("Data root: %s", dataRoot)
+		t.Debugf("Data root: %s", dataRoot)
 
 		reader := gather.NewOutputReader(filepath.Join(outputDir, clusters.C1, dataRoot))
 		testOutputReader(t, reader)
 	})
 }
 
-func testOutputReader(t *testing.T, reader *gather.OutputReader) {
+func testOutputReader(t *test.T, reader *gather.OutputReader) {
 	t.Helper()
 
-	t.Run("deployment", func(t *testing.T) {
+	t.Run("deployment", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		name := "common-busybox"
 		data, err := reader.ReadResource("test-common", "apps/deployments", name)
 		if err != nil {
@@ -76,10 +80,11 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 		if deployment.Name != name {
 			t.Errorf("expected deployment name %q, got %s", name, deployment.Name)
 		}
-		t.Logf("Read deployment %q", deployment.Name)
+		t.Debugf("Read deployment %q", deployment.Name)
 	})
 
-	t.Run("pods", func(t *testing.T) {
+	t.Run("pods", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		pods, err := reader.ListResources("test-common", "pods")
 		if err != nil {
 			t.Fatal(err)
@@ -87,7 +92,7 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 		if len(pods) == 0 {
 			t.Fatalf("no pod found")
 		}
-		t.Logf("Listed pods %q", pods)
+		t.Debugf("Listed pods %q", pods)
 
 		for _, name := range pods {
 			data, err := reader.ReadResource("test-common", "pods", name)
@@ -101,11 +106,12 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 			if pod.Name != name {
 				t.Errorf("expected pod name %q, got %s", name, pod.Name)
 			}
-			t.Logf("Read pod %q", pod.Name)
+			t.Debugf("Read pod %q", pod.Name)
 		}
 	})
 
-	t.Run("cluster scope", func(t *testing.T) {
+	t.Run("cluster scope", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		namespaces, err := reader.ListResources("", "namespaces")
 		if err != nil {
 			t.Fatal(err)
@@ -113,7 +119,7 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 		if len(namespaces) == 0 {
 			t.Fatalf("no namespaces found")
 		}
-		t.Logf("Listed namespaces %q", namespaces)
+		t.Debugf("Listed namespaces %q", namespaces)
 
 		for _, name := range namespaces {
 			data, err := reader.ReadResource("", "namespaces", name)
@@ -127,11 +133,12 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 			if namespace.Name != name {
 				t.Errorf("expected namespace name %q, got %s", name, namespace.Name)
 			}
-			t.Logf("Read namespace %q", namespace.Name)
+			t.Debugf("Read namespace %q", namespace.Name)
 		}
 	})
 
-	t.Run("missing namespaced", func(t *testing.T) {
+	t.Run("missing namespaced", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		found, err := reader.ListResources("test-common", "missing")
 		if err != nil {
 			t.Fatal(err)
@@ -141,7 +148,8 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 		}
 	})
 
-	t.Run("missing cluster scope", func(t *testing.T) {
+	t.Run("missing cluster scope", func(dt *testing.T) {
+		t := test.WithLog(dt)
 		found, err := reader.ListResources("", "missing")
 		if err != nil {
 			t.Fatal(err)
@@ -152,7 +160,8 @@ func testOutputReader(t *testing.T, reader *gather.OutputReader) {
 	})
 }
 
-func TestSecretSanitization(t *testing.T) {
+func TestSecretSanitization(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-secret-sanitization"
 
 	salt := gather.RandomSalt()
@@ -164,7 +173,7 @@ func TestSecretSanitization(t *testing.T) {
 		"--salt", saltB64,
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Fatalf("kubectl-gather failed: %s", err)
 	}
 
@@ -181,7 +190,8 @@ func TestSecretSanitization(t *testing.T) {
 	}
 }
 
-func TestSecretSanitizationRandomSalt(t *testing.T) {
+func TestSecretSanitizationRandomSalt(dt *testing.T) {
+	t := test.WithLog(dt)
 	outputDir := "out/test-secret-sanitization-random"
 
 	cmd := exec.Command(
@@ -189,7 +199,7 @@ func TestSecretSanitizationRandomSalt(t *testing.T) {
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd); err != nil {
+	if err := commands.Run(cmd, t.Log); err != nil {
 		t.Fatalf("kubectl-gather failed: %s", err)
 	}
 
@@ -211,7 +221,7 @@ func TestSecretSanitizationRandomSalt(t *testing.T) {
 // Test helpers
 
 // gatheredSecrets returns all secrets gathered for a cluster.
-func gatheredSecrets(t *testing.T, outputDir, cluster string) []core.Secret {
+func gatheredSecrets(t *test.T, outputDir, cluster string) []core.Secret {
 	t.Helper()
 	pattern := filepath.Join(outputDir, cluster, "namespaces", "*", "secrets", "*.yaml")
 	files, err := filepath.Glob(pattern)

--- a/e2e/test/testing.go
+++ b/e2e/test/testing.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/nirs/kubectl-gather/e2e/logging"
+)
+
+var logger *zap.SugaredLogger
+
+// Main creates the test logger and runs the tests. Must be called from
+// TestMain.
+func Main(m *testing.M) {
+	var err error
+	logger, err = logging.NewTestLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = logger.Sync() }()
+	m.Run()
+}
+
+// T extends testing.T to log test errors and fatals to a debug log file.
+type T struct {
+	*testing.T
+	Log *zap.SugaredLogger
+}
+
+// WithLog returns a T wrapping dt with a named logger.
+func WithLog(dt *testing.T) *T {
+	return &T{T: dt, Log: logger.Named(dt.Name())}
+}
+
+func (t *T) Errorf(format string, args ...any) {
+	t.Helper()
+	t.Log.Errorf(format, args...)
+	t.Fail()
+}
+
+func (t *T) Fatal(args ...any) {
+	t.Helper()
+	t.Log.Error(args...)
+	t.FailNow()
+}
+
+func (t *T) Fatalf(format string, args ...any) {
+	t.Helper()
+	t.Log.Errorf(format, args...)
+	t.FailNow()
+}
+
+func (t *T) Debugf(format string, args ...any) {
+	t.Log.Debugf(format, args...)
+}

--- a/e2e/test/testing_test.go
+++ b/e2e/test/testing_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestErrorfLogs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger = zap.New(core).Named("test").Sugar()
+	tt := WithLog(t)
+
+	tt.Log.Errorf("test error: %s", "something went wrong")
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Level != zapcore.ErrorLevel {
+		t.Errorf("expected ERROR level, got %s", entry.Level)
+	}
+	if entry.Message != "test error: something went wrong" {
+		t.Errorf("unexpected message: %s", entry.Message)
+	}
+}
+
+func TestFatalfLogs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger = zap.New(core).Named("test").Sugar()
+	tt := WithLog(t)
+
+	tt.Log.Errorf("fatal error: %s", "cannot continue")
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Level != zapcore.ErrorLevel {
+		t.Errorf("expected ERROR level, got %s", entry.Level)
+	}
+	if entry.Message != "fatal error: cannot continue" {
+		t.Errorf("unexpected message: %s", entry.Message)
+	}
+}
+
+func TestDebugfLogs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger = zap.New(core).Named("test").Sugar()
+	tt := WithLog(t)
+
+	tt.Debugf("debug message: %d", 42)
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Level != zapcore.DebugLevel {
+		t.Errorf("expected DEBUG level, got %s", entry.Level)
+	}
+	if entry.Message != "debug message: 42" {
+		t.Errorf("unexpected message: %s", entry.Message)
+	}
+}

--- a/e2e/validate/validate.go
+++ b/e2e/validate/validate.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"testing"
+
+	"github.com/nirs/kubectl-gather/e2e/test"
 )
 
 // Validator checks that gathered resources exist or are missing in the output
@@ -26,7 +27,7 @@ func (v *Validator) WithDataRoot(dataRoot string) *Validator {
 	return &Validator{outputDir: v.outputDir, dataRoot: dataRoot}
 }
 
-func (v *Validator) Exists(t *testing.T, clusterNames []string, resources ...[]string) {
+func (v *Validator) Exists(t *test.T, clusterNames []string, resources ...[]string) {
 	t.Helper()
 
 	if !PathExists(t, v.outputDir) {
@@ -51,7 +52,7 @@ func (v *Validator) Exists(t *testing.T, clusterNames []string, resources ...[]s
 	}
 }
 
-func (v *Validator) Missing(t *testing.T, clusterNames []string, resources ...[]string) {
+func (v *Validator) Missing(t *test.T, clusterNames []string, resources ...[]string) {
 	t.Helper()
 
 	if !PathExists(t, v.outputDir) {
@@ -73,7 +74,7 @@ func (v *Validator) Missing(t *testing.T, clusterNames []string, resources ...[]
 	}
 }
 
-func JSONLog(t *testing.T, logPath string) {
+func JSONLog(t *test.T, logPath string) {
 	if !PathExists(t, logPath) {
 		t.Fatalf("log %q does not exist", logPath)
 	}
@@ -95,7 +96,7 @@ func JSONLog(t *testing.T, logPath string) {
 	}
 }
 
-func PathExists(t *testing.T, path string) bool {
+func PathExists(t *test.T, path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		if !os.IsNotExist(err) {
 			t.Fatalf("error checking path %q: %v", path, err)


### PR DESCRIPTION
Adds structured logging to the e2e test infrastructure. Previously,
all output (minikube commands, kubectl-gather logs, test errors) was
dumped to the console, making it hard to follow test runs and
impossible to debug CI failures after the fact. Now the console shows
only high-level progress, while a comprehensive debug log captures
everything in a single file that is uploaded as a CI artifact.

## Changes

- **Cleaner console output**: cluster operations show only high-level
  INFO messages (creating cluster, loading image, configuring DNS).
  All command output and debug details are kept out of the console.

- **Full debug log**: all command executions, minikube output,
  kubectl-gather logs, and test failure messages are written to
  `e2e/out/e2e.log`. Both the e2e CLI and test suite write to the
  same log file with consistent formatting (ISO8601 timestamps,
  named loggers per cluster and test).

- **Test failures in the log**: test errors and fatals are logged at
  ERROR level before marking the test as failed, so they appear in
  the debug log alongside the commands that led to the failure.

- **Debug log in CI artifacts**: `e2e.log` is now included in the
  uploaded test artifacts, making it possible to debug CI failures
  without reproducing locally.

- **Build tags**: e2e test files use `//go:build e2e` so
  `go test ./...` runs safely without clusters. `make unit-tests`
  now uses `go test ./...` to discover all unit tests automatically.
  Editor setup for the build tag is documented in CONTRIBUTING.md.

- **Keep test output after cleanup**: `make clean` no longer deletes
  `e2e/out`, so test output and logs can be inspected after removing
  the clusters. In CI, clusters are deleted before archiving so the
  log file includes cleanup output.

## Future work

- Move `kubectl apply`, `kubectl rollout`, and `podman build` from
  Makefile recipes into `e2e/cmd` subcommands (`deploy`, `container`)
  so their output is also captured in the debug log.