### PR TITLE
Add ramen addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,12 +519,47 @@ $ du -sh gather.remote.app/
 2.7M	gather.remote.app/
 ```
 
-## Enabling specific addons
+## Addons
 
-By default we gather additional data like pod container logs and rook
-commands and external logs stored on the nodes. To control gathering of
-additional data, you can use the `--addons` flag. If the flag is not set
-all addons are enabled.
+Addons enrich gathered resources and collect related data. By default all
+addons are enabled.
+
+### logs
+
+Gathers current and previous container logs for pods.
+
+### pvcs
+
+Gathers related PersistentVolumes and StorageClasses for
+PersistentVolumeClaims.
+
+### ramen
+
+Annotates DRPlacementControl and VolumeReplicationGroup resources with
+the cluster time when the resource was gathered:
+
+```yaml
+metadata:
+  annotations:
+    kubectl-gather.nirs.github.com/cluster-time: "2026-05-08T18:44:02Z"
+```
+
+This enables tools like ramenctl to validate replication freshness
+offline by comparing `lastGroupSyncTime` against the cluster time.
+
+For DRPlacementControl resources, the addon also gathers the referenced
+DRPolicy (cluster-scoped), which contains the scheduling interval
+needed for validation.
+
+### rook
+
+Gathers ceph commands output and external logs from nodes for
+CephClusters.
+
+### Enabling specific addons
+
+To control which addons are enabled, use the `--addons` flag. If the
+flag is not set all addons are enabled.
 
 Gathering only resources:
 

--- a/pkg/gather/addons.go
+++ b/pkg/gather/addons.go
@@ -4,6 +4,7 @@
 package gather
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -44,13 +45,16 @@ func (a *addonMeta) Name() string { return a.name }
 type addonFunc func(AddonBackend) (Addon, error)
 
 type addonInfo struct {
-	Resource  string
+	Resources []string
 	AddonFunc addonFunc
 }
 
 var addonRegistry = map[string]addonInfo{}
 
 func registerAddon(name string, ai addonInfo) {
+	if _, exists := addonRegistry[name]; exists {
+		panic(fmt.Sprintf("addon %q already registered", name))
+	}
 	addonRegistry[name] = ai
 }
 
@@ -63,7 +67,12 @@ func createAddons(backend AddonBackend) (map[string]Addon, error) {
 			if err != nil {
 				return nil, err
 			}
-			registry[addonInfo.Resource] = addon
+			for _, resource := range addonInfo.Resources {
+				if other, exists := registry[resource]; exists {
+					return nil, fmt.Errorf("addon %q: resource %q already registered by addon %q", name, resource, other.Name())
+				}
+				registry[resource] = addon
+			}
 		}
 	}
 

--- a/pkg/gather/addons.go
+++ b/pkg/gather/addons.go
@@ -34,6 +34,13 @@ type AddonBackend interface {
 	GatherResource(schema.GroupVersionResource, types.NamespacedName)
 }
 
+// addonMeta provides common addon metadata like name.
+type addonMeta struct {
+	name string
+}
+
+func (a *addonMeta) Name() string { return a.name }
+
 type addonFunc func(AddonBackend) (Addon, error)
 
 type addonInfo struct {

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -57,6 +57,9 @@ type Options struct {
 }
 
 type Addon interface {
+	// Name returns the addon name.
+	Name() string
+
 	// Inspect a resource and gather related data. The clusterTime is the
 	// approximate time on the cluster when the resource was listed. If the
 	// cluster time is not available, clusterTime is nil.

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -57,8 +57,10 @@ type Options struct {
 }
 
 type Addon interface {
-	// Inspect a resource and gather related data.
-	Inspect(*unstructured.Unstructured) error
+	// Inspect a resource and gather related data. The clusterTime is the
+	// approximate time on the cluster when the resource was listed. If the
+	// cluster time is not available, clusterTime is nil.
+	Inspect(*unstructured.Unstructured, *time.Time) error
 }
 
 type Gatherer struct {
@@ -183,6 +185,34 @@ func (g *Gatherer) Gather() error {
 
 func (g *Gatherer) Count() int {
 	return len(g.resources)
+}
+
+// clusterTime returns the current time on the cluster by reading the Date
+// header from an API server response.
+func (g *Gatherer) clusterTime() (*time.Time, error) {
+	req, err := http.NewRequest("GET", g.config.Host+"/version", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	date := resp.Header.Get("Date")
+	if date == "" {
+		return nil, fmt.Errorf("no Date header in response")
+	}
+
+	t, err := http.ParseTime(date)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
 }
 
 func (g *Gatherer) prepare() error {
@@ -343,6 +373,24 @@ func (g *Gatherer) shouldGather(gv schema.GroupVersion, res *metav1.APIResource)
 func (g *Gatherer) gatherResources(r *resourceInfo, namespace string) {
 	start := time.Now()
 
+	addon := g.addons[r.Name()]
+
+	// Get the cluster time before listing. A list response is a consistent
+	// snapshot created by the API server shortly after the request, so the
+	// cluster time captured here is a close approximation of the snapshot
+	// time. Paginated lists use the same snapshot, so we don't need to get
+	// the time again for subsequent pages.
+	var snapshotTime *time.Time
+	if addon != nil {
+		var err error
+		snapshotTime, err = g.clusterTime()
+		if err != nil {
+			g.log.Warnf("Cannot get cluster time for %q, using local time: %s", r.Name(), err)
+			now := time.Now()
+			snapshotTime = &now
+		}
+	}
+
 	opts := metav1.ListOptions{Limit: listResourcesLimit}
 	count := 0
 
@@ -368,8 +416,6 @@ func (g *Gatherer) gatherResources(r *resourceInfo, namespace string) {
 			}
 		}
 
-		addon := g.addons[r.Name()]
-
 		for i := range list.Items {
 			item := &list.Items[i]
 			key := g.keyFromResource(r, item)
@@ -381,7 +427,7 @@ func (g *Gatherer) gatherResources(r *resourceInfo, namespace string) {
 			count += 1
 
 			if addon != nil {
-				if err := addon.Inspect(item); err != nil {
+				if err := addon.Inspect(item, snapshotTime); err != nil {
 					g.log.Warnf("Cannot inspect %q: %s", key, err)
 				}
 			}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -380,14 +380,14 @@ func (g *Gatherer) gatherResources(r *resourceInfo, namespace string) {
 
 			count += 1
 
-			if err := g.dumpResource(r, item); err != nil {
-				g.log.Warnf("Cannot dump %q: %s", key, err)
-			}
-
 			if addon != nil {
 				if err := addon.Inspect(item); err != nil {
 					g.log.Warnf("Cannot inspect %q: %s", key, err)
 				}
+			}
+
+			if err := g.dumpResource(r, item); err != nil {
+				g.log.Warnf("Cannot dump %q: %s", key, err)
 			}
 		}
 

--- a/pkg/gather/logs.go
+++ b/pkg/gather/logs.go
@@ -20,6 +20,7 @@ const (
 )
 
 type LogsAddon struct {
+	addonMeta
 	AddonBackend
 	client *kubernetes.Clientset
 	log    *zap.SugaredLogger
@@ -50,6 +51,7 @@ func NewLogsAddon(backend AddonBackend) (Addon, error) {
 	}
 
 	return &LogsAddon{
+		addonMeta:    addonMeta{name: logsName},
 		AddonBackend: backend,
 		client:       client,
 		log:          backend.Options().Log.Named(logsName),

--- a/pkg/gather/logs.go
+++ b/pkg/gather/logs.go
@@ -39,7 +39,7 @@ func (c containerInfo) String() string {
 
 func init() {
 	registerAddon(logsName, addonInfo{
-		Resource:  "pods",
+		Resources: []string{"pods"},
 		AddonFunc: NewLogsAddon,
 	})
 }

--- a/pkg/gather/logs.go
+++ b/pkg/gather/logs.go
@@ -56,7 +56,7 @@ func NewLogsAddon(backend AddonBackend) (Addon, error) {
 	}, nil
 }
 
-func (a *LogsAddon) Inspect(pod *unstructured.Unstructured) error {
+func (a *LogsAddon) Inspect(pod *unstructured.Unstructured, _ *time.Time) error {
 	a.log.Debugf("Inspecting pod \"%s/%s\"", pod.GetNamespace(), pod.GetName())
 
 	containers, err := a.listContainers(pod)

--- a/pkg/gather/pvcs.go
+++ b/pkg/gather/pvcs.go
@@ -4,6 +4,8 @@
 package gather
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -34,7 +36,7 @@ func NewPVCAddon(backend AddonBackend) (Addon, error) {
 	}, nil
 }
 
-func (a *pvcsAddon) Inspect(pvc *unstructured.Unstructured) error {
+func (a *pvcsAddon) Inspect(pvc *unstructured.Unstructured, _ *time.Time) error {
 	// When cluster flag is set, PV and StorageClass resources are already gathered at cluster level
 	if a.Options().Cluster {
 		return nil

--- a/pkg/gather/pvcs.go
+++ b/pkg/gather/pvcs.go
@@ -18,6 +18,7 @@ const (
 )
 
 type pvcsAddon struct {
+	addonMeta
 	AddonBackend
 	log *zap.SugaredLogger
 }
@@ -31,6 +32,7 @@ func init() {
 
 func NewPVCAddon(backend AddonBackend) (Addon, error) {
 	return &pvcsAddon{
+		addonMeta:    addonMeta{name: pvcsName},
 		AddonBackend: backend,
 		log:          backend.Options().Log.Named(pvcsName),
 	}, nil

--- a/pkg/gather/pvcs.go
+++ b/pkg/gather/pvcs.go
@@ -25,7 +25,7 @@ type pvcsAddon struct {
 
 func init() {
 	registerAddon(pvcsName, addonInfo{
-		Resource:  "persistentvolumeclaims",
+		Resources: []string{"persistentvolumeclaims"},
 		AddonFunc: NewPVCAddon,
 	})
 }

--- a/pkg/gather/ramen.go
+++ b/pkg/gather/ramen.go
@@ -25,7 +25,7 @@ type ramenAddon struct {
 
 func init() {
 	registerAddon(ramenName, addonInfo{
-		Resource:  "ramendr.openshift.io/drplacementcontrols",
+		Resources: []string{"ramendr.openshift.io/drplacementcontrols"},
 		AddonFunc: NewRamenAddon,
 	})
 }

--- a/pkg/gather/ramen.go
+++ b/pkg/gather/ramen.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: The kubectl-gather authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	ramenName             = "ramen"
+	clusterTimeAnnotation = "kubectl-gather.nirs.github.com/cluster-time"
+)
+
+type ramenAddon struct {
+	AddonBackend
+	log *zap.SugaredLogger
+}
+
+func init() {
+	registerAddon(ramenName, addonInfo{
+		Resource:  "ramendr.openshift.io/drplacementcontrols",
+		AddonFunc: NewRamenAddon,
+	})
+}
+
+func NewRamenAddon(backend AddonBackend) (Addon, error) {
+	return &ramenAddon{
+		AddonBackend: backend,
+		log:          backend.Options().Log.Named(ramenName),
+	}, nil
+}
+
+func (a *ramenAddon) Inspect(item *unstructured.Unstructured, clusterTime *time.Time) error {
+	a.log.Debugf("Inspecting drpc \"%s/%s\"", item.GetNamespace(), item.GetName())
+
+	if clusterTime != nil {
+		a.annotateClusterTime(item, clusterTime)
+	}
+
+	a.gatherDRPolicy(item)
+
+	return nil
+}
+
+func (a *ramenAddon) annotateClusterTime(item *unstructured.Unstructured, clusterTime *time.Time) {
+	annotations := item.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[clusterTimeAnnotation] = clusterTime.UTC().Format(time.RFC3339)
+	item.SetAnnotations(annotations)
+}
+
+func (a *ramenAddon) gatherDRPolicy(item *unstructured.Unstructured) {
+	ref, found, err := unstructured.NestedMap(item.Object, "spec", "drPolicyRef")
+	if err != nil {
+		a.log.Warnf("Cannot get drpc \"%s/%s\" drPolicyRef: %s",
+			item.GetNamespace(), item.GetName(), err)
+		return
+	}
+	if !found {
+		a.log.Warnf("Missing drPolicyRef in drpc \"%s/%s\"",
+			item.GetNamespace(), item.GetName())
+		return
+	}
+
+	apiVersion, _ := ref["apiVersion"].(string)
+	name, _ := ref["name"].(string)
+	if apiVersion == "" || name == "" {
+		a.log.Warnf("Invalid drPolicyRef in drpc \"%s/%s\"",
+			item.GetNamespace(), item.GetName())
+		return
+	}
+
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		a.log.Warnf("Cannot parse drPolicyRef apiVersion %q: %s", apiVersion, err)
+		return
+	}
+
+	gvr := gv.WithResource("drpolicies")
+	a.GatherResource(gvr, types.NamespacedName{Name: name})
+}

--- a/pkg/gather/ramen.go
+++ b/pkg/gather/ramen.go
@@ -18,6 +18,7 @@ const (
 )
 
 type ramenAddon struct {
+	addonMeta
 	AddonBackend
 	log *zap.SugaredLogger
 }
@@ -31,6 +32,7 @@ func init() {
 
 func NewRamenAddon(backend AddonBackend) (Addon, error) {
 	return &ramenAddon{
+		addonMeta:    addonMeta{name: ramenName},
 		AddonBackend: backend,
 		log:          backend.Options().Log.Named(ramenName),
 	}, nil

--- a/pkg/gather/ramen.go
+++ b/pkg/gather/ramen.go
@@ -25,7 +25,10 @@ type ramenAddon struct {
 
 func init() {
 	registerAddon(ramenName, addonInfo{
-		Resources: []string{"ramendr.openshift.io/drplacementcontrols"},
+		Resources: []string{
+			"ramendr.openshift.io/drplacementcontrols",
+			"ramendr.openshift.io/volumereplicationgroups",
+		},
 		AddonFunc: NewRamenAddon,
 	})
 }
@@ -39,13 +42,16 @@ func NewRamenAddon(backend AddonBackend) (Addon, error) {
 }
 
 func (a *ramenAddon) Inspect(item *unstructured.Unstructured, clusterTime *time.Time) error {
-	a.log.Debugf("Inspecting drpc \"%s/%s\"", item.GetNamespace(), item.GetName())
+	kind := item.GetKind()
+	a.log.Debugf("Inspecting %s \"%s/%s\"", kind, item.GetNamespace(), item.GetName())
 
 	if clusterTime != nil {
 		a.annotateClusterTime(item, clusterTime)
 	}
 
-	a.gatherDRPolicy(item)
+	if kind == "DRPlacementControl" {
+		a.gatherDRPolicy(item)
+	}
 
 	return nil
 }

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -23,6 +23,7 @@ const (
 )
 
 type RookAddon struct {
+	addonMeta
 	AddonBackend
 	client *kubernetes.Clientset
 	log    *zap.SugaredLogger
@@ -42,6 +43,7 @@ func NewRookAddon(backend AddonBackend) (Addon, error) {
 	}
 
 	return &RookAddon{
+		addonMeta:    addonMeta{name: rookName},
 		AddonBackend: backend,
 		client:       clientSet,
 		log:          backend.Options().Log.Named(rookName),

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -31,7 +31,7 @@ type RookAddon struct {
 
 func init() {
 	registerAddon(rookName, addonInfo{
-		Resource:  "ceph.rook.io/cephclusters",
+		Resources: []string{"ceph.rook.io/cephclusters"},
 		AddonFunc: NewRookAddon,
 	})
 }

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -48,7 +48,7 @@ func NewRookAddon(backend AddonBackend) (Addon, error) {
 	}, nil
 }
 
-func (a *RookAddon) Inspect(cephcluster *unstructured.Unstructured) error {
+func (a *RookAddon) Inspect(cephcluster *unstructured.Unstructured, _ *time.Time) error {
 	namespace := cephcluster.GetNamespace()
 	a.log.Debugf("Inspecting cephcluster \"%s/%s\"", namespace, cephcluster.GetName())
 


### PR DESCRIPTION
## Infrastructure changes

- Call `Inspect()` before `dumpResource()`, allowing addons to enrich
  resources before they are written to disk
- Add `clusterTime()` to get the API server time from the `Date`
  response header, passed to `Inspect()` as `*time.Time`. Falls back
  to local time if the cluster time is unavailable, so the annotation
  is always present.
- Add `Name()` method to the `Addon` interface via embedded
  `addonMeta` type, providing common addon metadata
- Support multiple resources per addon: `addonInfo.Resource` (string)
  becomes `Resources` ([]string), with duplicate detection for both
  addon names and resources

## Ramen addon

Add a ramen addon that handles DRPlacementControl and
VolumeReplicationGroup resources:

- Annotates both DRPC and VRG resources with the cluster time
- Gathers the referenced DRPolicy for DRPC resources

### Motivation

To validate replication freshness, ramenctl needs to compare
`lastGroupSyncTime` against the time the resource was actually
gathered — not local time, which may be wrong.

The VRG on the managed cluster is the ground truth for sync times,
updated as soon as the underlying replication CRs report a new sync.
The DRPC on the hub is a copy, updated every ~30 seconds. By
annotating both with the cluster time, ramenctl can:

- Validate replication freshness from the VRG for more precise results
- Fall back to the DRPC on the hub when managed cluster data is not
  available

### Example output

Annotated DRPC with cluster time and `lastGroupSyncTime`:

```yaml
metadata:
  annotations:
    kubectl-gather.nirs.github.com/cluster-time: "2026-05-07T21:40:26Z"
...
status:
  lastGroupSyncTime: "2026-05-07T21:34:00Z"
```

The gathered DRPolicy (cluster-scoped):

```yaml
apiVersion: ramendr.openshift.io/v1alpha1
kind: DRPolicy
metadata:
  name: my-policy-5
spec:
  schedulingInterval: 5m
  drClusters:
  - amagrawa-c1
  - amagrawa-c2
```

With the gathered DRPolicy and the cluster-time annotation, ramenctl
can validate the time since the last sync, and report replication
problems.

## Documentation

Added an Addons section to the README describing each addon: logs,
pvcs, ramen, and rook.

## Testing

- [x] Tested with real OCP cluster (hub in US, client in Middle East)
- [x] Verified DRPC annotation present in gathered output
- [x] Verified VRG annotation present in gathered output
- [x] Verified DRPolicy gathered as cluster-scoped resource

---
Fixes #29