### PR TITLE
gather: move secret sanitization to secrets addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,10 +560,18 @@ needed for validation.
 Gathers ceph commands output and external logs from nodes for
 CephClusters.
 
+### secrets
+
+Sanitizes Secret resources by replacing data values with deterministic
+PBKDF2-HMAC-SHA256 hashes. The secrets addon is always enabled unless
+`--insecure-secrets` is set. See [Secret
+sanitization](#secret-sanitization) for more info.
+
 ### Enabling specific addons
 
 To control which addons are enabled, use the `--addons` flag. If the
-flag is not set all addons are enabled.
+flag is not set all addons are enabled. The secrets addon is always
+included unless `--insecure-secrets` is set.
 
 Gathering only resources:
 
@@ -571,7 +579,7 @@ Gathering only resources:
 $ kubectl gather --contexts dr1,dr2 --addons= -d gather.resources
 2024-06-01T02:13:08.117+0300	INFO	gather	Using kubeconfig "/home/nsoffer/.kube/config"
 2024-06-01T02:13:08.118+0300	INFO	gather	Gathering from all namespaces
-2024-06-01T02:13:08.119+0300	INFO	gather	Using addons []
+2024-06-01T02:13:08.119+0300	INFO	gather	Using addons ["secrets"]
 2024-06-01T02:13:08.119+0300	INFO	gather	Gathering from cluster "dr1"
 2024-06-01T02:13:08.119+0300	INFO	gather	Gathering from cluster "dr2"
 2024-06-01T02:13:08.942+0300	INFO	gather	Gathered 557 resources from cluster "dr1" in 0.823 seconds
@@ -585,7 +593,7 @@ Gathering resource and pod container logs:
 $ kubectl gather --contexts dr1,dr2 --addons logs -d gather.logs
 2024-06-01T02:12:07.775+0300	INFO	gather	Using kubeconfig "/home/nsoffer/.kube/config"
 2024-06-01T02:12:07.776+0300	INFO	gather	Gathering from all namespaces
-2024-06-01T02:12:07.777+0300	INFO	gather	Using addons ["logs"]
+2024-06-01T02:12:07.777+0300	INFO	gather	Using addons ["logs","secrets"]
 2024-06-01T02:12:07.777+0300	INFO	gather	Gathering from cluster "dr1"
 2024-06-01T02:12:07.777+0300	INFO	gather	Gathering from cluster "dr2"
 2024-06-01T02:12:11.580+0300	INFO	gather	Gathered 553 resources from cluster "dr2" in 3.803 seconds
@@ -618,10 +626,14 @@ $ du -sh gather.*
 
 ## Secret sanitization
 
-All Secret resources are automatically sanitized before writing. Each
-data value is replaced with a deterministic PBKDF2-HMAC-SHA256 hash,
-and the `kubectl.kubernetes.io/last-applied-configuration` annotation
-is stripped to prevent plaintext leaks.
+The `secrets` addon automatically sanitizes all Secret resources before
+writing. Each data value is replaced with a deterministic
+PBKDF2-HMAC-SHA256 hash, and the
+`kubectl.kubernetes.io/last-applied-configuration` annotation is
+stripped to prevent plaintext leaks. The secrets addon is always enabled
+unless `--insecure-secrets` is set. Use `--insecure-secrets` to disable
+sanitization for debugging or in test environments where secrets are not
+sensitive.
 
 A `kubectl-gather.nirs.github.com/sanitized` annotation is added to
 each sanitized secret with the base64-encoded salt. The salt can be

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -96,9 +96,13 @@ func mustGatherCommand(context string, directory string) *exec.Cmd {
 		remoteArgs = append(remoteArgs, "--addons="+strings.Join(addons, ","))
 	}
 
-	// Always pass the salt so all remote clusters use the same salt value,
-	// ensuring consistent hashes for comparing secrets across clusters.
-	remoteArgs = append(remoteArgs, "--salt="+salt)
+	if insecureSecrets {
+		remoteArgs = append(remoteArgs, "--insecure-secrets")
+	} else {
+		// Pass the salt so all remote clusters use the same salt value,
+		// ensuring consistent hashes for comparing secrets across clusters.
+		remoteArgs = append(remoteArgs, "--salt="+salt)
+	}
 
 	if len(remoteArgs) > 0 {
 		args = append(args, "--", "/usr/bin/gather")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var namespaces []string
 var addons []string
 var cluster bool
 var remote bool
+var insecureSecrets bool
 var salt string
 var parsedSalt gather.Salt
 var verbose bool
@@ -52,8 +53,8 @@ var example = `  # Gather data from all namespaces in current context in my-kube
   # clusters use the same salt for consistent secret hashing.
   kubectl gather --contexts dr1,dr2,hub --remote --salt "$(openssl rand -base64 16)" --directory gather.remote
 
-  # Enable only the "logs" addon, gathering all resources and pod logs. Use
-  # --addons= to disable all addons.
+  # Enable only the "logs" addon, gathering all resources and pod logs.
+  # The secrets addon is always included unless --insecure-secrets is set.
   kubectl gather --contexts dr1,dr2,hub --addons logs --directory gather.resources+logs
 
   # Gather both cluster and namespace resources from "my-ns" and "other-ns" in clusters
@@ -102,6 +103,8 @@ func init() {
 			"specified, gather all resources")
 	rootCmd.Flags().BoolVarP(&remote, "remote", "r", false,
 		"run on the remote clusters (requires the \"oc\" command)")
+	rootCmd.Flags().BoolVar(&insecureSecrets, "insecure-secrets", false,
+		"disable secret sanitization for debugging or testing")
 	rootCmd.Flags().StringVar(&salt, "salt", "",
 		"base64-encoded 16-byte salt for secret hashing (default: randomly generated)")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
@@ -145,10 +148,12 @@ func runGather(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	if cmd.Flags().Changed("salt") {
-		log.Infof("Using user-provided salt %q", salt)
-	} else {
-		log.Infof("Using generated salt %q", salt)
+	if !insecureSecrets {
+		if cmd.Flags().Changed("salt") {
+			log.Infof("Using user-provided salt %q", salt)
+		} else {
+			log.Infof("Using generated salt %q", salt)
+		}
 	}
 
 	if namespaces == nil {
@@ -179,16 +184,37 @@ func runGather(cmd *cobra.Command, args []string) {
 }
 
 func validateOptions(cmd *cobra.Command) error {
-	if salt != "" {
-		var err error
-		parsedSalt, err = validateSalt(salt)
-		if err != nil {
-			return err
+	if insecureSecrets && cmd.Flags().Changed("salt") {
+		return fmt.Errorf("--salt and --insecure-secrets cannot be used together")
+	}
+
+	if !insecureSecrets {
+		if salt != "" {
+			var err error
+			parsedSalt, err = validateSalt(salt)
+			if err != nil {
+				return err
+			}
+		} else {
+			parsedSalt = gather.RandomSalt()
+			// Keep the base64 salt string for logging and passing to remote clusters.
+			salt = base64.StdEncoding.EncodeToString(parsedSalt[:])
 		}
-	} else {
-		parsedSalt = gather.RandomSalt()
-		// Keep the base64 salt string for logging and passing to remote clusters.
-		salt = base64.StdEncoding.EncodeToString(parsedSalt[:])
+	}
+
+	if insecureSecrets {
+		// When --insecure-secrets is set and --addons is not specified, addons
+		// is nil which enables all addons including secrets. Build an explicit
+		// list excluding secrets so addonEnabled skips it.
+		if addons == nil {
+			for _, name := range gather.AvailableAddons() {
+				if name != "secrets" {
+					addons = append(addons, name)
+				}
+			}
+		}
+	} else if addons != nil && !slices.Contains(addons, "secrets") {
+		addons = append(addons, "secrets")
 	}
 
 	// --namespaces=""

--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -220,6 +220,35 @@ func TestSecretSanitizationRandomSalt(dt *testing.T) {
 	}
 }
 
+func TestSecretSanitizationDisabled(dt *testing.T) {
+	t := test.WithLog(dt)
+	outputDir := "out/test-secret-sanitization-disabled"
+
+	cmd := exec.Command(
+		kubectlGather,
+		"--contexts", strings.Join(clusters.Names, ","),
+		"--insecure-secrets",
+		"--directory", outputDir,
+	)
+	if err := commands.Run(cmd, t.Log); err != nil {
+		t.Fatalf("kubectl-gather failed: %s", err)
+	}
+
+	for _, cluster := range clusters.Names {
+		for _, secret := range gatheredSecrets(t, outputDir, cluster) {
+			_, ok := secret.Annotations["kubectl-gather.nirs.github.com/sanitized"]
+			if ok {
+				t.Errorf("secret %s: should not be sanitized when --insecure-secrets is set", secret.Name)
+			}
+			for key, value := range secret.Data {
+				if len(value) == 0 {
+					t.Errorf("secret %s: key %q has empty data", secret.Name, key)
+				}
+			}
+		}
+	}
+}
+
 // Test helpers
 
 // gatheredSecrets returns all secrets gathered for a cluster.

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -513,8 +513,6 @@ func (g *Gatherer) getResource(r *resourceInfo, name types.NamespacedName) (*uns
 }
 
 func (g *Gatherer) dumpResource(r *resourceInfo, item *unstructured.Unstructured) error {
-	g.sanitizeResource(item)
-
 	dst, err := g.createResource(r, item)
 	if err != nil {
 		return err

--- a/pkg/gather/sanitize.go
+++ b/pkg/gather/sanitize.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 
+	"go.uber.org/zap"
 	"golang.org/x/crypto/pbkdf2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -44,23 +45,11 @@ func HashValue(data []byte, salt Salt) []byte {
 	return pbkdf2.Key(data, salt[:], pbkdf2Iterations, sha256.Size, sha256.New)
 }
 
-// sanitizeResource modifies the resource in place, replacing sensitive data
-// with deterministic hashes. Currently handles Secret resources, other resource
-// types pass through unchanged.
-func (g *Gatherer) sanitizeResource(item *unstructured.Unstructured) {
-	switch item.GetKind() {
-	case "Secret":
-		g.sanitizeSecret(item)
-	}
-}
-
 // sanitizeSecret hashes secret data values and strips the
 // last-applied-configuration annotation.
-func (g *Gatherer) sanitizeSecret(item *unstructured.Unstructured) {
-	log := g.opts.Log
+func sanitizeSecret(item *unstructured.Unstructured, salt Salt, log *zap.SugaredLogger) {
 	obj := item.Object
 	name := item.GetName()
-	salt := g.opts.Salt
 	saltB64 := base64.StdEncoding.EncodeToString(salt[:])
 
 	// If already sanitized, skip to avoid double hashing.

--- a/pkg/gather/sanitize_test.go
+++ b/pkg/gather/sanitize_test.go
@@ -16,20 +16,19 @@ import (
 
 var testSalt = Salt{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-func TestSanitizeResource(t *testing.T) {
+func TestSanitizeSecret(t *testing.T) {
 	tests := []string{
 		"secret-with-data",
 		"secret-with-annotations",
 		"secret-empty",
-		"configmap",
 	}
 
-	g := newTestGatherer(testSalt)
+	log := zap.NewNop().Sugar()
 
 	for _, name := range tests {
 		t.Run(name, func(t *testing.T) {
 			obj := loadTestdata(t, name+".yaml")
-			g.sanitizeResource(obj)
+			sanitizeSecret(obj, testSalt, log)
 			actual := marshalYAML(t, obj.Object)
 
 			golden := filepath.Join("testdata", "sanitize", name+".golden.yaml")
@@ -45,13 +44,13 @@ func TestSanitizeResource(t *testing.T) {
 }
 
 func TestSanitizeSecretIdempotent(t *testing.T) {
-	g := newTestGatherer(testSalt)
+	log := zap.NewNop().Sugar()
 
 	obj := loadTestdata(t, "secret-with-data.yaml")
-	g.sanitizeResource(obj)
+	sanitizeSecret(obj, testSalt, log)
 	expected := marshalYAML(t, obj.Object)
 
-	g.sanitizeResource(obj)
+	sanitizeSecret(obj, testSalt, log)
 	actual := marshalYAML(t, obj.Object)
 
 	if expected != actual {
@@ -60,14 +59,15 @@ func TestSanitizeSecretIdempotent(t *testing.T) {
 }
 
 func TestSanitizeSecretDifferentSalts(t *testing.T) {
-	g1 := newTestGatherer(RandomSalt())
-	g2 := newTestGatherer(RandomSalt())
+	log := zap.NewNop().Sugar()
+	salt1 := RandomSalt()
+	salt2 := RandomSalt()
 
 	s1 := loadTestdata(t, "secret-with-data.yaml")
 	s2 := loadTestdata(t, "secret-with-data.yaml")
 
-	g1.sanitizeResource(s1)
-	g2.sanitizeResource(s2)
+	sanitizeSecret(s1, salt1, log)
+	sanitizeSecret(s2, salt2, log)
 
 	d1, found, err := unstructured.NestedStringMap(s1.Object, "data")
 	if err != nil || !found {
@@ -101,15 +101,6 @@ func BenchmarkHashValue(b *testing.B) {
 }
 
 // Test helpers
-
-func newTestGatherer(salt Salt) *Gatherer {
-	return &Gatherer{
-		opts: &Options{
-			Salt: salt,
-			Log:  zap.NewNop().Sugar(),
-		},
-	}
-}
 
 func loadTestdata(t *testing.T, name string) *unstructured.Unstructured {
 	t.Helper()

--- a/pkg/gather/secrets.go
+++ b/pkg/gather/secrets.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The kubectl-gather authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	secretsName = "secrets"
+)
+
+type secretsAddon struct {
+	addonMeta
+	AddonBackend
+	log *zap.SugaredLogger
+}
+
+func init() {
+	registerAddon(secretsName, addonInfo{
+		Resources: []string{"secrets"},
+		AddonFunc: NewSecretsAddon,
+	})
+}
+
+func NewSecretsAddon(backend AddonBackend) (Addon, error) {
+	return &secretsAddon{
+		addonMeta:    addonMeta{name: secretsName},
+		AddonBackend: backend,
+		log:          backend.Options().Log.Named(secretsName),
+	}, nil
+}
+
+func (a *secretsAddon) Inspect(item *unstructured.Unstructured, _ *time.Time) error {
+	a.log.Debugf("Inspecting secret \"%s/%s\"", item.GetNamespace(), item.GetName())
+	sanitizeSecret(item, a.Options().Salt, a.log)
+	return nil
+}


### PR DESCRIPTION
Move secret sanitization from dumpResource() into a dedicated secrets addon, making sanitization an addon concern rather than part of the core write path.

The secrets addon is always enabled by default to prevent accidental secret leakage. The `--insecure-secrets` flag allows explicitly disabling sanitization for debugging or testing environments where secrets are not sensitive.

Testing:

1. Default (no flags) secrets should be sanitized:

```
./kubectl-gather --contexts c1,c2 -d out/secret-sanitized
2026-07-21T17:42:51.957+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
2026-07-21T17:42:51.962+0530	INFO	gather	Using generated salt "tJI8cUJz4c8o+bGZp2JMrA=="
2026-07-21T17:42:51.962+0530	INFO	gather	Gathering from all namespaces
2026-07-21T17:42:51.962+0530	INFO	gather	Gathering cluster scoped resources
2026-07-21T17:42:51.962+0530	INFO	gather	Using all addons
2026-07-21T17:42:51.962+0530	INFO	gather	Gathering from cluster "c1"
2026-07-21T17:42:51.962+0530	INFO	gather	Gathering from cluster "c2"
2026-07-21T17:42:52.292+0530	INFO	gather	Gathered 329 resources from cluster "c2" in 0.330 seconds
2026-07-21T17:42:52.295+0530	INFO	gather	Gathered 328 resources from cluster "c1" in 0.333 seconds
2026-07-21T17:42:52.295+0530	INFO	gather	Gathered 657 resources from 2 clusters in 0.333 seconds

apiVersion: v1
data:
  secret1: IWEZrM7whuCR3mAZjrvTj2RsB1o1uIn+02v2FWqI41o=
  secret2: xPS1ucoTcO11xvc0YZT2/GsGbR2OGzwDZBUR/67xarA=
kind: Secret
metadata:
  annotations:
    kubectl-gather.nirs.github.com/sanitized: tJI8cUJz4c8o+bGZp2JMrA==
  creationTimestamp: "2026-07-20T10:05:34Z"
  ....
```
2. --insecure-secrets -- secrets should NOT be sanitized:
```
./kubectl-gather --contexts c1,c2 --insecure-secrets -d out/secret-insecure
2026-07-21T17:43:20.531+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
2026-07-21T17:43:20.535+0530	INFO	gather	Gathering from all namespaces
2026-07-21T17:43:20.535+0530	INFO	gather	Gathering cluster scoped resources
2026-07-21T17:43:20.535+0530	INFO	gather	Using addons ["logs" "pvcs" "ramen" "rook"]
2026-07-21T17:43:20.535+0530	INFO	gather	Gathering from cluster "c1"
2026-07-21T17:43:20.535+0530	INFO	gather	Gathering from cluster "c2"
2026-07-21T17:43:20.719+0530	INFO	gather	Gathered 328 resources from cluster "c1" in 0.184 seconds
2026-07-21T17:43:20.779+0530	INFO	gather	Gathered 329 resources from cluster "c2" in 0.243 seconds
2026-07-21T17:43:20.779+0530	INFO	gather	Gathered 657 resources from 2 clusters in 0.244 seconds

apiVersion: v1
data:
  secret1: c2VjcmV0MQ==
  secret2: c2VjcmV0Mg==
kind: Secret
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"secret1":"c2VjcmV0MQ==","secret2":"c2VjcmV0Mg=="},"kind":"Secret","metadata":{"annotations":{},"name":"common-secret1","namespace":"test-common"},"type":"Opaque"}
  creationTimestamp: "2026-07-20T10:05:34Z"
```
3. --addons=logs -- secrets auto-added:
```
./kubectl-gather --contexts c1,c2 --addons=logs -d out/test-addons-logs
2026-07-21T17:43:58.834+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
2026-07-21T17:43:58.839+0530	INFO	gather	Using generated salt "O02lpVNZs3AbLTbqPhYdnA=="
2026-07-21T17:43:58.839+0530	INFO	gather	Gathering from all namespaces
2026-07-21T17:43:58.839+0530	INFO	gather	Gathering cluster scoped resources
2026-07-21T17:43:58.839+0530	INFO	gather	Using addons ["logs" "secrets"]
2026-07-21T17:43:58.839+0530	INFO	gather	Gathering from cluster "c1"
2026-07-21T17:43:58.839+0530	INFO	gather	Gathering from cluster "c2"
2026-07-21T17:43:59.199+0530	INFO	gather	Gathered 329 resources from cluster "c2" in 0.360 seconds
2026-07-21T17:43:59.214+0530	INFO	gather	Gathered 328 resources from cluster "c1" in 0.374 seconds
2026-07-21T17:43:59.214+0530	INFO	gather	Gathered 657 resources from 2 clusters in 0.374 seconds
```

5. --addons= (empty) -- secrets should still be injected:
```
./kubectl-gather --contexts c1,c2 --addons= -d out/test-addons-empty
2026-07-21T17:44:05.738+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
2026-07-21T17:44:05.738+0530	INFO	gather	Using generated salt "x2ztM37BWYPAnHzlwryuPg=="
2026-07-21T17:44:05.738+0530	INFO	gather	Gathering from all namespaces
2026-07-21T17:44:05.738+0530	INFO	gather	Gathering cluster scoped resources
2026-07-21T17:44:05.738+0530	INFO	gather	Using addons ["secrets"]
2026-07-21T17:44:05.738+0530	INFO	gather	Gathering from cluster "c1"
2026-07-21T17:44:05.739+0530	INFO	gather	Gathering from cluster "c2"
2026-07-21T17:44:06.045+0530	INFO	gather	Gathered 329 resources from cluster "c2" in 0.307 seconds
2026-07-21T17:44:06.049+0530	INFO	gather	Gathered 328 resources from cluster "c1" in 0.310 seconds
2026-07-21T17:44:06.049+0530	INFO	gather	Gathered 657 resources from 2 clusters in 0.310 seconds
```

6. --addons= --insecure-secrets -- truly bare:
```
./kubectl-gather --contexts c1,c2 --addons= --insecure-secrets -d out/test-bare
2026-07-21T17:44:20.280+0530	INFO	gather	Using kubeconfig "/Users/pari/.kube/config"
2026-07-21T17:44:20.285+0530	INFO	gather	Gathering from all namespaces
2026-07-21T17:44:20.285+0530	INFO	gather	Gathering cluster scoped resources
2026-07-21T17:44:20.285+0530	INFO	gather	Using addons []
2026-07-21T17:44:20.285+0530	INFO	gather	Gathering from cluster "c1"
2026-07-21T17:44:20.285+0530	INFO	gather	Gathering from cluster "c2"
2026-07-21T17:44:20.398+0530	INFO	gather	Gathered 329 resources from cluster "c2" in 0.113 seconds
2026-07-21T17:44:20.400+0530	INFO	gather	Gathered 328 resources from cluster "c1" in 0.116 seconds
2026-07-21T17:44:20.400+0530	INFO	gather	Gathered 657 resources from 2 clusters in 0.116 seconds
```
7. --salt + --insecure-secrets -- should error:
```
./kubectl-gather --contexts c1,c2 --salt "$(openssl rand -base64 16)" --insecure-secrets -d out/test-conflict
2026-07-21T17:44:31.576+0530	FATAL	gather	--salt and --insecure-secrets cannot be used together
```


Fixes #166 
Fixes #123