### PR TITLE
Add spell checking to CI workflow and fix spelling errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,17 @@ permissions:
 
 jobs:
 
+  spell:
+    name: Check spelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          skip: go.sum
+
   tidy:
     name: Go Mod Tidy
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ ldflags := -s -w \
 	all \
 	kubectl-gather \
 	lint \
+	spell \
 	test \
 	unit-tests \
 	e2e-tests \
@@ -56,6 +57,9 @@ all: kubectl-gather
 
 lint:
 	golangci-lint run ./...
+
+spell:
+	codespell -w --skip="go.sum,out,e2e/out"
 
 test: unit-tests e2e-tests
 

--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ small when gathering only a few namespaces.
 ## Integrating with other programs
 
 When running the *kubectl gather* from another program you may want to
-use JSON logs to extract certain fileds from the gather logs.
+use JSON logs to extract certain fields from the gather logs.
 
 Example: extracting the "msg" field from gather JSON logs:
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -5,7 +5,7 @@
 kubectl-gather fetch and process data in a 3 steps pipeline:
 
 ```
-prepare --> gather --> inpsect
+prepare --> gather --> inspect
 ```
 
 ### Prepare step


### PR DESCRIPTION
This PR adds automated spell checking to the codebase and fixes existing spelling errors:

1. Added spell checking:
   - Created a "spell" job in the CI workflow using codespell-project/actions-codespell@v2
   - Added a matching `make spell` command for local development
   - Configured both to skip go.sum

2. Fixed existing spelling errors:
   - README.md: fileds -> fields
   - docs/internals.md: inpsect -> inspect

Fixes: #84