### PR TITLE
lint: Add golines formatter and make fmt target

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,9 +27,13 @@ formatters:
   enable:
     - gofmt
     - goimports
+    - golines
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    golines:
+      shorten-comments: true

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ ldflags := -s -w \
 	all \
 	kubectl-gather \
 	lint \
+	fmt \
 	spell \
 	test \
 	unit-tests \
@@ -57,6 +58,9 @@ all: kubectl-gather
 
 lint:
 	golangci-lint run ./...
+
+fmt:
+	golangci-lint fmt
 
 spell:
 	codespell -w --skip="go.sum,out,e2e/out"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,8 @@ func init() {
 		"base64-encoded 16-byte salt for secret hashing (default: randomly generated)")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
 		"be more verbose")
-	rootCmd.Flags().StringVar(&logFormat, "log-format", "text", "Set the logging format [text, json]")
+	rootCmd.Flags().StringVar(&logFormat, "log-format", "text",
+		"Set the logging format [text, json]")
 	rootCmd.Flags().BoolVar(&mustGatherVersion, "must-gather-version", false,
 		"print must-gather version info and exit")
 

--- a/pkg/gather/addons.go
+++ b/pkg/gather/addons.go
@@ -69,7 +69,12 @@ func createAddons(backend AddonBackend) (map[string]Addon, error) {
 			}
 			for _, resource := range addonInfo.Resources {
 				if other, exists := registry[resource]; exists {
-					return nil, fmt.Errorf("addon %q: resource %q already registered by addon %q", name, resource, other.Name())
+					return nil, fmt.Errorf(
+						"addon %q: resource %q already registered by addon %q",
+						name,
+						resource,
+						other.Name(),
+					)
 				}
 				registry[resource] = addon
 			}

--- a/pkg/gather/agent.go
+++ b/pkg/gather/agent.go
@@ -83,9 +83,13 @@ type agentWatcher struct {
 	agent *AgentPod
 }
 
-func (w *agentWatcher) WatchWithContext(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (w *agentWatcher) WatchWithContext(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
 	w.agent.Log.Debugf("Watching agent pod %q", w.agent)
-	opts.FieldSelector = fields.OneTermEqualSelector(metav1.ObjectNameField, w.agent.Pod.Name).String()
+	opts.FieldSelector = fields.OneTermEqualSelector(metav1.ObjectNameField, w.agent.Pod.Name).
+		String()
 	return w.agent.Client.CoreV1().Pods(w.agent.Pod.Namespace).Watch(ctx, opts)
 }
 

--- a/pkg/gather/commands.go
+++ b/pkg/gather/commands.go
@@ -24,7 +24,12 @@ type RemoteCommand struct {
 
 var specialCharacters *regexp.Regexp
 
-func NewRemoteCommand(pod *corev1.Pod, opts *Options, log *zap.SugaredLogger, directory string) *RemoteCommand {
+func NewRemoteCommand(
+	pod *corev1.Pod,
+	opts *Options,
+	log *zap.SugaredLogger,
+	directory string,
+) *RemoteCommand {
 	return &RemoteCommand{pod: pod, opts: opts, log: log, directory: directory}
 }
 

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -306,7 +306,11 @@ func (g *Gatherer) listAPIResources() ([]resourceInfo, error) {
 		}
 	}
 
-	g.log.Debugf("Listed %d api resources in %.3f seconds", len(resources), time.Since(start).Seconds())
+	g.log.Debugf(
+		"Listed %d api resources in %.3f seconds",
+		len(resources),
+		time.Since(start).Seconds(),
+	)
 
 	return resources, nil
 }
@@ -449,7 +453,11 @@ func (g *Gatherer) gatherResources(r *resourceInfo, namespace string) {
 	g.log.Debugf("Gathered %d %q in %.3f seconds", count, r.Name(), time.Since(start).Seconds())
 }
 
-func (g *Gatherer) listResources(r *resourceInfo, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (g *Gatherer) listResources(
+	r *resourceInfo,
+	namespace string,
+	opts metav1.ListOptions,
+) (*unstructured.UnstructuredList, error) {
 	start := time.Now()
 
 	ctx := context.TODO()
@@ -469,7 +477,12 @@ func (g *Gatherer) listResources(r *resourceInfo, namespace string, opts metav1.
 		return nil, err
 	}
 
-	g.log.Debugf("Listed %d %q in %.3f seconds", len(list.Items), r.Name(), time.Since(start).Seconds())
+	g.log.Debugf(
+		"Listed %d %q in %.3f seconds",
+		len(list.Items),
+		r.Name(),
+		time.Since(start).Seconds(),
+	)
 
 	return list, nil
 }
@@ -498,7 +511,10 @@ func (g *Gatherer) gatherResource(gvr schema.GroupVersionResource, name types.Na
 	g.log.Debugf("Gathered %q in %.3f seconds", key, time.Since(start).Seconds())
 }
 
-func (g *Gatherer) getResource(r *resourceInfo, name types.NamespacedName) (*unstructured.Unstructured, error) {
+func (g *Gatherer) getResource(
+	r *resourceInfo,
+	name types.NamespacedName,
+) (*unstructured.Unstructured, error) {
 	ctx := context.TODO()
 	var opts metav1.GetOptions
 
@@ -530,7 +546,10 @@ func (g *Gatherer) dumpResource(r *resourceInfo, item *unstructured.Unstructured
 	return writer.Flush()
 }
 
-func (g *Gatherer) createResource(r *resourceInfo, item *unstructured.Unstructured) (io.WriteCloser, error) {
+func (g *Gatherer) createResource(
+	r *resourceInfo,
+	item *unstructured.Unstructured,
+) (io.WriteCloser, error) {
 	if r.Namespaced {
 		return g.output.CreateNamespacedResource(item.GetNamespace(), r.Name(), item.GetName())
 	} else {

--- a/pkg/gather/logs.go
+++ b/pkg/gather/logs.go
@@ -183,7 +183,12 @@ func (a *LogsAddon) listContainers(pod *unstructured.Unstructured) ([]*container
 //
 // See also https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L1453
 func containerHasPreviousLog(status map[string]interface{}) bool {
-	containerID, found, err := unstructured.NestedString(status, "lastState", "terminated", "containerID")
+	containerID, found, err := unstructured.NestedString(
+		status,
+		"lastState",
+		"terminated",
+		"containerID",
+	)
 	if err != nil || !found {
 		return false
 	}

--- a/pkg/gather/output.go
+++ b/pkg/gather/output.go
@@ -21,7 +21,12 @@ type OutputDirectory struct {
 	base string
 }
 
-func (o *OutputDirectory) CreateContainerLog(namespace string, pod string, container string, name string) (io.WriteCloser, error) {
+func (o *OutputDirectory) CreateContainerLog(
+	namespace string,
+	pod string,
+	container string,
+	name string,
+) (io.WriteCloser, error) {
 	dir, err := createDirectory(o.base, namespacesDir, namespace, "pods", pod, container)
 	if err != nil {
 		return nil, err
@@ -29,7 +34,11 @@ func (o *OutputDirectory) CreateContainerLog(namespace string, pod string, conta
 	return createFile(dir, name+logSuffix)
 }
 
-func (o *OutputDirectory) CreateNamespacedResource(namespace string, resource string, name string) (io.WriteCloser, error) {
+func (o *OutputDirectory) CreateNamespacedResource(
+	namespace string,
+	resource string,
+	name string,
+) (io.WriteCloser, error) {
 	dir, err := createDirectory(o.base, namespacesDir, namespace, resource)
 	if err != nil {
 		return nil, err
@@ -37,7 +46,10 @@ func (o *OutputDirectory) CreateNamespacedResource(namespace string, resource st
 	return createFile(dir, name+resourceSuffix)
 }
 
-func (o *OutputDirectory) CreateClusterResource(resource string, name string) (io.WriteCloser, error) {
+func (o *OutputDirectory) CreateClusterResource(
+	resource string,
+	name string,
+) (io.WriteCloser, error) {
 	dir, err := createDirectory(o.base, clusterDir, resource)
 	if err != nil {
 		return nil, err

--- a/pkg/gather/output_reader.go
+++ b/pkg/gather/output_reader.go
@@ -55,7 +55,13 @@ func (r *OutputReader) ReadResource(namespace, resource, name string) ([]byte, e
 	if namespace == "" {
 		resourcePath = filepath.Join(r.base, clusterDir, resource, name+resourceSuffix)
 	} else {
-		resourcePath = filepath.Join(r.base, namespacesDir, namespace, resource, name+resourceSuffix)
+		resourcePath = filepath.Join(
+			r.base,
+			namespacesDir,
+			namespace,
+			resource,
+			name+resourceSuffix,
+		)
 	}
 	return os.ReadFile(resourcePath)
 }

--- a/pkg/gather/rook.go
+++ b/pkg/gather/rook.go
@@ -108,7 +108,12 @@ func (a *RookAddon) gatherCommand(rc *RemoteCommand, command ...string) {
 }
 
 func (a *RookAddon) logCollectorEnabled(cephcluster *unstructured.Unstructured) bool {
-	enabled, found, err := unstructured.NestedBool(cephcluster.Object, "spec", "logCollector", "enabled")
+	enabled, found, err := unstructured.NestedBool(
+		cephcluster.Object,
+		"spec",
+		"logCollector",
+		"enabled",
+	)
 	if err != nil {
 		a.log.Warnf("Cannot get cephcluster .spec.logCollector.enabled: %s", err)
 	}

--- a/pkg/gather/sanitize.go
+++ b/pkg/gather/sanitize.go
@@ -64,7 +64,12 @@ func (g *Gatherer) sanitizeSecret(item *unstructured.Unstructured) {
 	saltB64 := base64.StdEncoding.EncodeToString(salt[:])
 
 	// If already sanitized, skip to avoid double hashing.
-	existing, found, _ := unstructured.NestedString(obj, "metadata", "annotations", sanitizedAnnotation)
+	existing, found, _ := unstructured.NestedString(
+		obj,
+		"metadata",
+		"annotations",
+		sanitizedAnnotation,
+	)
 	if found {
 		if existing != saltB64 {
 			log.Warnf("Secret %q: already sanitized with different salt %q", name, existing)
@@ -98,7 +103,13 @@ func (g *Gatherer) sanitizeSecret(item *unstructured.Unstructured) {
 	unstructured.RemoveNestedField(obj, "metadata", "annotations", lastAppliedConfigAnnotation)
 
 	// Mark the secret as sanitized with the salt used.
-	if err := unstructured.SetNestedField(obj, saltB64, "metadata", "annotations", sanitizedAnnotation); err != nil {
+	if err := unstructured.SetNestedField(
+		obj,
+		saltB64,
+		"metadata",
+		"annotations",
+		sanitizedAnnotation,
+	); err != nil {
 		log.Warnf("Secret %q: failed to set sanitized annotation: %s", name, err)
 	}
 }

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -135,7 +135,12 @@ func loadContexts(contexts []string, kubeconfig string) ([]*Config, error) {
 			return nil, err
 		}
 		if prev, ok := hosts[restConfig.Host]; ok {
-			return nil, fmt.Errorf("duplicate cluster %q from contexts %q and %q", restConfig.Host, prev, context)
+			return nil, fmt.Errorf(
+				"duplicate cluster %q from contexts %q and %q",
+				restConfig.Host,
+				prev,
+				context,
+			)
 		}
 		hosts[restConfig.Host] = context
 		configs = append(configs, &Config{
@@ -190,7 +195,12 @@ func loadKubeconfigs(kubeconfigs []string) ([]*Config, error) {
 		name := nameFromFilename(path)
 
 		if prev, ok := names[name]; ok {
-			return nil, fmt.Errorf("duplicate cluster name %q from files %q and %q", name, prev, path)
+			return nil, fmt.Errorf(
+				"duplicate cluster name %q from files %q and %q",
+				name,
+				prev,
+				path,
+			)
 		}
 		names[name] = path
 
@@ -211,7 +221,12 @@ func loadKubeconfigs(kubeconfigs []string) ([]*Config, error) {
 		}
 
 		if prev, ok := hosts[restConfig.Host]; ok {
-			return nil, fmt.Errorf("duplicate cluster %q from files %q and %q", restConfig.Host, prev, path)
+			return nil, fmt.Errorf(
+				"duplicate cluster %q from files %q and %q",
+				restConfig.Host,
+				prev,
+				path,
+			)
 		}
 		hosts[restConfig.Host] = path
 


### PR DESCRIPTION
Fixes #85

Add golines to the golangci-lint formatters so long lines and comments are wrapped automatically, matching the pattern used in RamenDR/ramenctl#140.
With this change, `make fmt` runs all formatters (gofmt, goimports,golines) in one command.
Ran `make fmt` once to reformat the existing codebase — the diff ispurely line-wrapping, no logic changes. `make lint` and
`make unit-tests` both pass.