### PR TITLE
lint: forbid os.Exit and log.Fatal in pkg/

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,12 +6,23 @@ linters:
   enable:
     - errcheck
     - nolintlint
+    - forbidigo
     # TODO: enable after fixing issues
     #- gocritic
     #- gosec
     #- misspell
     #- stylecheck
     #- unconvert
+  settings:
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: '^os\.Exit$'
+          msg: "os.Exit() is forbidden in library code; return an error instead"
+        - pattern: '^log\.(Logger\.)?(Fatal|Fatalf|Fatalln)$'
+          msg: "log.Fatal() is forbidden in library code; return an error instead"
+        - pattern: '^zap\.(Logger|SugaredLogger)\.(Fatal|Fatalf|Fatalln|Fatalw)$'
+          msg: "zap Fatal() calls os.Exit; return an error instead"
   exclusions:
     generated: lax
     presets:
@@ -23,6 +34,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - path-except: '^pkg/'
+        linters:
+          - forbidigo
 formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ all: kubectl-gather
 
 lint:
 	golangci-lint run ./...
+	if golangci-lint run --enable-only=forbidigo ./pkg/gather/testdata/forbidigo; then \
+		echo "probe not flagged"; \
+		exit 1; \
+	fi
 
 fmt:
 	golangci-lint fmt

--- a/pkg/gather/testdata/forbidigo/probe.go
+++ b/pkg/gather/testdata/forbidigo/probe.go
@@ -1,0 +1,20 @@
+package forbidigo
+
+import (
+	stdlog "log"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func forbidden(log *zap.SugaredLogger, logger *zap.Logger) {
+	os.Exit(1)
+	stdlog.Fatal("x")
+	stdlog.Fatalf("x")
+	stdlog.Fatalln("x")
+	logger.Fatal("x")
+	log.Fatal("x")
+	log.Fatalf("x")
+	log.Fatalln("x")
+	log.Fatalw("x")
+}


### PR DESCRIPTION
Closes #120

Adds forbidigo to .golangci.yaml, forbidding os.Exit() and log.Fatal() calls in library code. Configured to only run on pkg/ (excluded from cmd/ and e2e/ via linters.exclusions.rules, since this repo uses golangci-lint v2 config format).

Verified:

pkg/ currently has no existing violations
Temporarily added os.Exit(1) to pkg/gather/files.go and confirmed golangci-lint run ./pkg/... correctly flags it with the custom message