### PR TITLE
e2e: make commands.Run() more useful

### DIFF
--- a/e2e/commands/commands.go
+++ b/e2e/commands/commands.go
@@ -2,22 +2,40 @@ package commands
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"os/exec"
 
 	"go.uber.org/zap"
 )
 
-// Run a command logging lines from stderr.
-func Run(cmd *exec.Cmd, log *zap.SugaredLogger) error {
+// Result holds the outcome of a command run by Run.
+type Result struct {
+	ExitCode int
+	Stdout   bytes.Buffer
+	Stderr   bytes.Buffer
+	Err      error
+}
+
+// Run a command, logging lines from stderr and collecting output in Result.
+func Run(cmd *exec.Cmd, log *zap.SugaredLogger) Result {
+	var result Result
+
 	log.Debugf("Running %v", cmd)
+
+	cmd.Stdout = &result.Stdout
+
 	pipe, err := cmd.StderrPipe()
 	if err != nil {
-		return err
+		result.Err = err
+		return result
 	}
+
 	if err := cmd.Start(); err != nil {
-		return err
+		result.Err = err
+		return result
 	}
+
 	reader := bufio.NewReader(pipe)
 	for {
 		line, _, err := reader.ReadLine()
@@ -28,8 +46,19 @@ func Run(cmd *exec.Cmd, log *zap.SugaredLogger) error {
 			break
 		}
 		log.Debug(string(line))
+		result.Stderr.Write(line)
+		result.Stderr.WriteByte('\n')
 	}
-	return cmd.Wait()
+
+	err = cmd.Wait()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = ee.ExitCode()
+		}
+		result.Err = err
+	}
+
+	return result
 }
 
 func Stderr(err error) []byte {

--- a/e2e/gather_test.go
+++ b/e2e/gather_test.go
@@ -104,8 +104,8 @@ func TestGatherLocal(dt *testing.T) {
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validateGatherAll(t, validate.New(outputDir))
@@ -121,8 +121,8 @@ func TestGatherClusterTrue(dt *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validateGatherAll(t, validate.New(outputDir))
@@ -142,8 +142,8 @@ func TestGatherRemote(dt *testing.T) {
 		"--remote",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Fatalf("kubectl-gather --remote failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Fatalf("kubectl-gather --remote failed: %s", r.Err)
 	}
 
 	dataRoot := findDataRoot(t, filepath.Join(outputDir, clusters.C1))
@@ -163,8 +163,8 @@ func TestGatherMultipleKubeconfigs(dt *testing.T) {
 		"--kubeconfig", strings.Join(kubeconfigs, ","),
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validateGatherAll(t, validate.New(outputDir))
@@ -186,8 +186,8 @@ func TestGatherMultipleKubeconfigsRemote(dt *testing.T) {
 		"--remote",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Fatalf("kubectl-gather --remote failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Fatalf("kubectl-gather --remote failed: %s", r.Err)
 	}
 
 	dataRoot := findDataRoot(t, filepath.Join(outputDir, clusters.C1))
@@ -206,8 +206,8 @@ func TestGatherClusterFalse(dt *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -256,7 +256,7 @@ func TestGatherEmptyNamespaces(dt *testing.T) {
 		"--namespaces=", "",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err == nil {
+	if r := commands.Run(cmd, t.Log); r.Err == nil {
 		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
@@ -274,7 +274,7 @@ func TestGatherEmptyNamespacesClusterFalse(dt *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err == nil {
+	if r := commands.Run(cmd, t.Log); r.Err == nil {
 		t.Errorf("kubectl-gather should fail, but it succeeded")
 	}
 
@@ -292,8 +292,8 @@ func TestGatherEmptyNamespacesClusterTrue(dt *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -342,8 +342,8 @@ func TestGatherSpecificNamespaces(dt *testing.T) {
 		"--namespaces", "test-common,test-c1",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validateSpecificNamespaces(t, validate.New(outputDir))
@@ -360,8 +360,8 @@ func TestGatherSpecificNamespacesClusterFalse(dt *testing.T) {
 		"--cluster=false",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validateSpecificNamespaces(t, validate.New(outputDir))
@@ -378,8 +378,8 @@ func TestGatherSpecificNamespacesClusterTrue(dt *testing.T) {
 		"--cluster=true",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -423,8 +423,8 @@ func TestGatherAddonsLogs(dt *testing.T) {
 		"--addons", "logs",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -469,8 +469,8 @@ func TestGatherAddonsPVCs(dt *testing.T) {
 		"--addons", "pvcs",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -512,8 +512,8 @@ func TestGatherAddonsEmpty(dt *testing.T) {
 		"--addons=",
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	v := validate.New(outputDir)
@@ -561,8 +561,8 @@ func TestJSONLogs(dt *testing.T) {
 		"--directory", outputDir,
 		"--log-format", "json",
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Errorf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Errorf("kubectl-gather failed: %s", r.Err)
 	}
 
 	validate.JSONLog(t, logPath)

--- a/e2e/output_test.go
+++ b/e2e/output_test.go
@@ -30,8 +30,8 @@ func TestOutput(t *testing.T) {
 			"--contexts", clusters.C1,
 			"--directory", outputDir,
 		)
-		if err := commands.Run(cmd, t.Log); err != nil {
-			t.Fatal(err)
+		if r := commands.Run(cmd, t.Log); r.Err != nil {
+			t.Fatal(r.Err)
 		}
 
 		reader := gather.NewOutputReader(filepath.Join(outputDir, clusters.C1))
@@ -53,8 +53,8 @@ func TestOutput(t *testing.T) {
 			"--remote",
 			"--directory", outputDir,
 		)
-		if err := commands.Run(cmd, t.Log); err != nil {
-			t.Fatal(err)
+		if r := commands.Run(cmd, t.Log); r.Err != nil {
+			t.Fatal(r.Err)
 		}
 
 		dataRoot := findDataRoot(t, filepath.Join(outputDir, clusters.C1))
@@ -175,8 +175,8 @@ func TestSecretSanitization(dt *testing.T) {
 		"--salt", saltB64,
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Fatalf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Fatalf("kubectl-gather failed: %s", r.Err)
 	}
 
 	for _, cluster := range clusters.Names {
@@ -201,8 +201,8 @@ func TestSecretSanitizationRandomSalt(dt *testing.T) {
 		"--contexts", strings.Join(clusters.Names, ","),
 		"--directory", outputDir,
 	)
-	if err := commands.Run(cmd, t.Log); err != nil {
-		t.Fatalf("kubectl-gather failed: %s", err)
+	if r := commands.Run(cmd, t.Log); r.Err != nil {
+		t.Fatalf("kubectl-gather failed: %s", r.Err)
 	}
 
 	salts := map[string]struct{}{}


### PR DESCRIPTION
Fixes #184

## Summary

Changes `commands.Run()` to return a `Result` struct instead of a plain `error`, so tests can assert on stderr output and exit codes in addition to checking for failure.

```go
type Result struct {
    ExitCode int
    Stdout   bytes.Buffer
    Stderr   bytes.Buffer
    Err      error
}
```

- Stderr lines are still streamed to the log line-by-line, exactly as before
- `Result.Stderr` collects the same stderr lines
- `Result.Stdout` collects stdout output
- `Result.ExitCode` is extracted from `*exec.ExitError` when the process exits non-zero
- `commands.Stderr()` is left unchanged — unrelated to `Run()`, only used by `minikube.go`

## Callers updated

All 19 call sites in `e2e/gather_test.go` and `e2e/output_test.go` migrated from:

```go
if err := commands.Run(cmd, t.Log); err != nil {
```

to:

```go
if r := commands.Run(cmd, t.Log); r.Err != nil {
```

including the two error-case tests (`TestGatherEmptyNamespaces`, `TestGatherEmptyNamespacesClusterFalse`) using `r.Err == nil`.
`e2e/clusters/minikube/minikube.go` is intentionally untouched per the issue, since it uses `exec.Command(...).Output()` directly, not `commands.Run()`.

## Testing

Set up minikube per CONTRIBUTING.md and ran the full suite locally:
```go
$ golangci-lint run ./...
```
0 issues.

```go
$ make test
```
...
$ go test -tags e2e ./e2e -v -count=1
=== RUN TestGatherEmptyNamespaces
--- PASS: TestGatherEmptyNamespaces (0.02s)
=== RUN TestGatherEmptyNamespacesClusterFalse
--- PASS: TestGatherEmptyNamespacesClusterFalse (0.02s)
=== RUN TestGatherEmptyNamespacesClusterTrue
--- PASS: TestGatherEmptyNamespacesClusterTrue (0.24s)
...
PASS
ok github.com/nirs/kubectl-gather/e2e 10.938s

All 20 tests using `commands.Run()` pass, including the exit-code path (`TestGatherEmptyNamespaces*`). The two `oc`-based remote tests skip as expected (`oc` not installed locally) — unrelated to this change. `go vet ./...`, `go vet -tags e2e ./e2e/...`, and `make fmt` are also clean.