### PR TITLE
Expose ResourceForKind() to addons

### DIFF
--- a/pkg/gather/addons.go
+++ b/pkg/gather/addons.go
@@ -33,6 +33,12 @@ type AddonBackend interface {
 
 	// GatherResource gathers the specified resource asynchronically.
 	GatherResource(schema.GroupVersionResource, types.NamespacedName)
+
+	// ResourceForKind returns the plural resource name for the given group
+	// and kind (e.g. ResourceForKind("", "PersistentVolume") returns
+	// "persistentvolumes"), based on api resources discovered from the
+	// cluster. Returns an empty string if the kind is not found.
+	ResourceForKind(group, kind string) string
 }
 
 // addonMeta provides common addon metadata like name.

--- a/pkg/gather/backend.go
+++ b/pkg/gather/backend.go
@@ -39,3 +39,7 @@ func (b *gatherBackend) Queue(work WorkFunc) {
 func (b *gatherBackend) GatherResource(gvr schema.GroupVersionResource, name types.NamespacedName) {
 	b.g.gatherResource(gvr, name)
 }
+
+func (b *gatherBackend) ResourceForKind(group, kind string) string {
+	return b.g.ResourceForKind(group, kind)
+}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -66,18 +66,24 @@ type Addon interface {
 	Inspect(*unstructured.Unstructured, *time.Time) error
 }
 
+type kindKey struct {
+	Group string
+	Kind  string
+}
+
 type Gatherer struct {
-	config       *rest.Config
-	httpClient   *http.Client
-	client       *dynamic.DynamicClient
-	addons       map[string]Addon
-	output       OutputDirectory
-	opts         *Options
-	gatherQueue  *WorkQueue
-	inspectQueue *WorkQueue
-	log          *zap.SugaredLogger
-	mutex        sync.Mutex
-	resources    map[string]struct{}
+	config          *rest.Config
+	httpClient      *http.Client
+	client          *dynamic.DynamicClient
+	addons          map[string]Addon
+	output          OutputDirectory
+	opts            *Options
+	gatherQueue     *WorkQueue
+	inspectQueue    *WorkQueue
+	log             *zap.SugaredLogger
+	mutex           sync.Mutex
+	resources       map[string]struct{}
+	resourceForKind map[kindKey]string
 }
 
 type resourceInfo struct {
@@ -123,15 +129,16 @@ func New(config *rest.Config, directory string, opts Options) (*Gatherer, error)
 	}
 
 	g := &Gatherer{
-		config:       config,
-		httpClient:   httpClient,
-		client:       client,
-		output:       OutputDirectory{base: directory},
-		opts:         &opts,
-		gatherQueue:  NewWorkQueue(workQueueSize),
-		inspectQueue: NewWorkQueue(workQueueSize),
-		log:          opts.Log,
-		resources:    make(map[string]struct{}),
+		config:          config,
+		httpClient:      httpClient,
+		client:          client,
+		output:          OutputDirectory{base: directory},
+		opts:            &opts,
+		gatherQueue:     NewWorkQueue(workQueueSize),
+		inspectQueue:    NewWorkQueue(workQueueSize),
+		log:             opts.Log,
+		resources:       make(map[string]struct{}),
+		resourceForKind: make(map[kindKey]string),
 	}
 
 	backend := &gatherBackend{
@@ -303,6 +310,7 @@ func (g *Gatherer) listAPIResources() ([]resourceInfo, error) {
 				GroupVersionResource: gv.WithResource(res.Name),
 				Namespaced:           res.Namespaced,
 			})
+			g.resourceForKind[kindKey{Group: gv.Group, Kind: res.Kind}] = res.Name
 		}
 	}
 
@@ -313,6 +321,14 @@ func (g *Gatherer) listAPIResources() ([]resourceInfo, error) {
 	)
 
 	return resources, nil
+}
+
+// ResourceForKind returns the plural resource name for the given group and
+// kind, as discovered from the cluster api resources during prepare. Returns
+// an empty string if the kind was not found (e.g. the api resource list has
+// not been gathered yet, or the kind does not exist on this cluster).
+func (g *Gatherer) ResourceForKind(group, kind string) string {
+	return g.resourceForKind[kindKey{Group: group, Kind: kind}]
 }
 
 // gatherNamespaces gathers the requested namespaces and return a list of

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: The kubectl-gather authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"testing"
+)
+
+func TestResourceForKind(t *testing.T) {
+	g := newTestGatherer(testSalt)
+	g.resourceForKind = map[kindKey]string{
+		{Group: "", Kind: "PersistentVolume"}:             "persistentvolumes",
+		{Group: "storage.k8s.io", Kind: "StorageClass"}:   "storageclasses",
+		{Group: "ramendr.openshift.io", Kind: "DRPolicy"}: "drpolicies",
+	}
+
+	tests := []struct {
+		name  string
+		group string
+		kind  string
+		want  string
+	}{
+		{
+			name:  "core group resource",
+			group: "",
+			kind:  "PersistentVolume",
+			want:  "persistentvolumes",
+		},
+		{
+			name:  "named group resource",
+			group: "storage.k8s.io",
+			kind:  "StorageClass",
+			want:  "storageclasses",
+		},
+		{
+			name:  "another named group resource",
+			group: "ramendr.openshift.io",
+			kind:  "DRPolicy",
+			want:  "drpolicies",
+		},
+		{
+			name:  "unknown kind",
+			group: "",
+			kind:  "NoSuchKind",
+			want:  "",
+		},
+		{
+			name:  "known kind in wrong group",
+			group: "wrong.group.io",
+			kind:  "PersistentVolume",
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := g.ResourceForKind(tc.group, tc.kind)
+			if got != tc.want {
+				t.Errorf("ResourceForKind(%q, %q) = %q, want %q",
+					tc.group, tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResourceForKindEmpty(t *testing.T) {
+	// A Gatherer built via New() always initializes resourceForKind, but
+	// guard against a nil map (e.g. a zero-value Gatherer in tests) still
+	// behaving as "not found" instead of panicking.
+	g := newTestGatherer(testSalt)
+
+	if got := g.ResourceForKind("", "PersistentVolume"); got != "" {
+		t.Errorf("ResourceForKind on empty map = %q, want empty string", got)
+	}
+}

--- a/pkg/gather/pvcs.go
+++ b/pkg/gather/pvcs.go
@@ -64,7 +64,12 @@ func (a *pvcsAddon) gatherPersistentVolume(pvc *unstructured.Unstructured) {
 		return
 	}
 
-	gvr := corev1.SchemeGroupVersion.WithResource("persistentvolumes")
+	resource := a.ResourceForKind("", "PersistentVolume")
+	if resource == "" {
+		a.log.Warnf("Cannot find resource for kind \"PersistentVolume\"")
+		return
+	}
+	gvr := corev1.SchemeGroupVersion.WithResource(resource)
 	a.GatherResource(gvr, types.NamespacedName{Name: name})
 }
 
@@ -80,6 +85,12 @@ func (a *pvcsAddon) gatherStorageClass(pvc *unstructured.Unstructured) {
 		return
 	}
 
-	gvr := storagev1.SchemeGroupVersion.WithResource("storageclasses")
+	resource := a.ResourceForKind(storagev1.SchemeGroupVersion.Group, "StorageClass")
+	if resource == "" {
+		a.log.Warnf("Cannot find resource for kind \"StorageClass\"")
+		return
+	}
+
+	gvr := storagev1.SchemeGroupVersion.WithResource(resource)
 	a.GatherResource(gvr, types.NamespacedName{Name: name})
 }

--- a/pkg/gather/ramen.go
+++ b/pkg/gather/ramen.go
@@ -92,6 +92,12 @@ func (a *ramenAddon) gatherDRPolicy(item *unstructured.Unstructured) {
 		return
 	}
 
-	gvr := gv.WithResource("drpolicies")
+	resource := a.ResourceForKind(gv.Group, "DRPolicy")
+	if resource == "" {
+		a.log.Warnf("Cannot find resource for kind \"DRPolicy\"")
+		return
+	}
+
+	gvr := gv.WithResource(resource)
 	a.GatherResource(gvr, types.NamespacedName{Name: name})
 }


### PR DESCRIPTION
## Summary

Addons that gather related resources currently hardcode the plural resource name (e.g. `"persistentvolumes"`, `"storageclasses"`, `"drpolicies"`). This is fragile — it requires knowing the exact plural form of every kind up front, and breaks if that ever changes or if a future addon needs to resolve an unfamiliar kind.

This PR adds `ResourceForKind(group, kind string) string` to `AddonBackend`, backed by data already fetched during discovery, so addons can resolve the plural resource name dynamically instead.

## Changes

- `Gatherer` now builds a `(group, kind) -> plural resource name` map while iterating discovered api resources in `listAPIResources()`  — no extra API calls, the data was already there.
- New `Gatherer.ResourceForKind()` method and matching `AddonBackend.ResourceForKind()` interface method, implemented on  `gatherBackend`. Returns `""` if the kind isn't found.
- `pvcsAddon` (`PersistentVolume`, `StorageClass`) and `ramenAddon` (`DRPolicy`) updated to resolve resource names through `ResourceForKind()` instead of hardcoding them, logging a warning and skipping the gather if a kind isn't found.
- Unit tests added in `pkg/gather/gather_test.go` covering known  kinds, unknown kinds, and kind/group mismatches.

## How this was tested

Ran the full test suite via `make lint` and `make test`, using local minikube clusters (`c1`/`c2`).

### `make lint`

golangci-lint run ./...
0 issues.


### `make test`

Unit tests, including the new `ResourceForKind` tests:

=== RUN TestResourceForKind
=== RUN TestResourceForKind/core_group_resource
=== RUN TestResourceForKind/named_group_resource
=== RUN TestResourceForKind/another_named_group_resource
=== RUN TestResourceForKind/unknown_kind
=== RUN TestResourceForKind/known_kind_in_wrong_group
--- PASS: TestResourceForKind (0.00s)
--- PASS: TestResourceForKind/core_group_resource (0.00s)
--- PASS: TestResourceForKind/named_group_resource (0.00s)
--- PASS: TestResourceForKind/another_named_group_resource (0.00s)
--- PASS: TestResourceForKind/unknown_kind (0.00s)
--- PASS: TestResourceForKind/known_kind_in_wrong_group (0.00s)
=== RUN TestResourceForKindEmpty
--- PASS: TestResourceForKindEmpty (0.00s)
PASS
ok github.com/nirs/kubectl-gather/pkg/gather 1.008s


e2e tests against local minikube clusters:

=== RUN TestGatherLocal
--- PASS: TestGatherLocal (1.34s)
=== RUN TestGatherClusterTrue
--- PASS: TestGatherClusterTrue (1.26s)
=== RUN TestGatherRemote
gather_test.go:134: oc not found, skipping remote test
--- SKIP: TestGatherRemote (0.00s)
=== RUN TestGatherMultipleKubeconfigs
--- PASS: TestGatherMultipleKubeconfigs (1.33s)
=== RUN TestGatherMultipleKubeconfigsRemote
gather_test.go:176: oc not found, skipping remote test
--- SKIP: TestGatherMultipleKubeconfigsRemote (0.00s)
=== RUN TestGatherClusterFalse
--- PASS: TestGatherClusterFalse (1.12s)
=== RUN TestGatherEmptyNamespaces
--- PASS: TestGatherEmptyNamespaces (0.02s)
=== RUN TestGatherEmptyNamespacesClusterFalse
--- PASS: TestGatherEmptyNamespacesClusterFalse (0.02s)
=== RUN TestGatherEmptyNamespacesClusterTrue
--- PASS: TestGatherEmptyNamespacesClusterTrue (0.26s)
=== RUN TestGatherSpecificNamespaces
--- PASS: TestGatherSpecificNamespaces (0.32s)
=== RUN TestGatherSpecificNamespacesClusterFalse
--- PASS: TestGatherSpecificNamespacesClusterFalse (0.37s)
=== RUN TestGatherSpecificNamespacesClusterTrue
--- PASS: TestGatherSpecificNamespacesClusterTrue (0.48s)
=== RUN TestGatherAddonsLogs
--- PASS: TestGatherAddonsLogs (0.40s)
=== RUN TestGatherAddonsPVCs
--- PASS: TestGatherAddonsPVCs (0.39s)
=== RUN TestGatherAddonsEmpty
--- PASS: TestGatherAddonsEmpty (0.38s)
=== RUN TestJSONLogs
--- PASS: TestJSONLogs (1.15s)
=== RUN TestOutput
--- PASS: TestOutput (1.04s)
=== RUN TestSecretSanitization
--- PASS: TestSecretSanitization (1.21s)
=== RUN TestSecretSanitizationRandomSalt
--- PASS: TestSecretSanitizationRandomSalt (1.19s)
PASS
ok github.com/nirs/kubectl-gather/e2e 12.333s


`TestGatherAddonsPVCs` is the relevant e2e coverage here — it exercises `pvcsAddon`, which calls `ResourceForKind` for `PersistentVolume` and `StorageClass` against real cluster discovery data, not just the unit test fixtures.

Two remote (`oc`) tests were skipped — `oc` isn't installed locally, unrelated to this change.

**Known gap:** the `ramenAddon`/`DRPolicy` path isn't exercised by an existing e2e test, only by the new unit tests in `gather_test.go`.

Happy to add e2e coverage for that if useful.

Fixes #167